### PR TITLE
Fix for EFA_0001 Boatstatus is always set to AVAILABLE instead of bas…

### DIFF
--- a/de/nmichael/efa/gui/EfaBaseFrame.java
+++ b/de/nmichael/efa/gui/EfaBaseFrame.java
@@ -4609,9 +4609,19 @@ public class EfaBaseFrame extends BaseDialog implements IItemListener {
                     break;
                 case EfaBaseFrame.MODE_BOATHOUSE_FINISH:
                 case EfaBaseFrame.MODE_BOATHOUSE_ABORT:
-                    newStatus = BoatStatusRecord.STATUS_AVAILABLE;
+                    //old newStatus = BoatStatusRecord.STATUS_AVAILABLE;
+                    if (boatStatusRecord == null) {
+                    	// Ein unbekanntes Boot - d.h. das nicht in der Bootliste ist
+                        // Dann gibt es keinen BoatStatusRecord-Objekt.
+                        // Setzen wir den neuen Status einfach auf Available
+                    	newStatus= BoatStatusRecord.STATUS_AVAILABLE;
+                    } else {
+                    	// bekanntes Boot - BoatStatusRecord auf den Basisstatus des Boots setzen.
+                    	newStatus=boatStatusRecord.getBaseStatus();
+                    }             
                     newComment = "";
                     break;
+
                 case EfaBaseFrame.MODE_BOATHOUSE_LATEENTRY:
                     break;
             }


### PR DESCRIPTION
…e status of the boat

Issue EFA_0001 - Boatstatus is always set to AVAILABLE instead of base status of the boat

If a session is finished or aborted, and the boat is within the list of boats, the boatstatus is set to the base state instead  of "available.