### PR TITLE
Efa 0025 boat damage list with filter replay

### DIFF
--- a/de/nmichael/efa/core/items/ItemTypeDataRecordTable.java
+++ b/de/nmichael/efa/core/items/ItemTypeDataRecordTable.java
@@ -434,71 +434,82 @@ public class ItemTypeDataRecordTable extends ItemTypeTable implements IItemListe
             showValue();
         }
         if (event != null && event instanceof KeyEvent && event.getID() == KeyEvent.KEY_RELEASED && itemType == searchField) {
-            String s = searchField.getValueFromField();
-            if (s != null && s.length() > 0 && keys != null && items != null) {
-                s = s.toLowerCase();
-                Vector<String> sv = null;
-                boolean[] sb = null;
-                if (s.indexOf(" ") > 0) {
-                    sv = EfaUtil.split(s, ' ');
-                    if (sv != null && sv.size() == 0) {
-                        sv = null;
-                    } else {
-                        sb = new boolean[sv.size()];
-                    }
-                }
-                int rowFound = -1;
-                for (int i = 0; rowFound < 0 && i < keys.length; i++) {
-                    // search in row i
-                    for (int j = 0; sb != null && j < sb.length; j++) {
-                        sb[j] = false; // matched parts of substring
-                    }
-
-                    TableItem[] row = items.get(keys[i]);
-                    for (int j = 0; row != null && rowFound < 0 && j < row.length; j++) {
-                        // search in row i, column j
-                        String t = (row[j] != null ? row[j].toString() : null);
-                        t = (t != null ? t.toLowerCase() : null);
-                        if (t == null) {
-                            continue;
-                        }
-
-                        // match entire search string against column
-                        if (t.indexOf(s) >= 0) {
-                            rowFound = i;
-                        }
-
-                        if (sv != null && rowFound < 0) {
-                            // match column agains substrings
-                            for (int k = 0; k < sv.size(); k++) {
-                                if (t.indexOf(sv.get(k)) >= 0) {
-                                    sb[k] = true;
-                                }
-                            }
-                        }
-                    }
-                    if (sb != null && rowFound < 0) {
-                        rowFound = i;
-                        for (int j = 0; j < sb.length; j++) {
-                            if (!sb[j]) {
-                                rowFound = -1;
-                            }
-                        }
-                    }
-                }
-                if (rowFound >= 0) {
-                    int currentIdx = table.getCurrentRowIndex(rowFound);
-                    if (currentIdx >= 0) {
-                        scrollToRow(currentIdx);
-                    }
-                }
-            }
+        	filterTableContents();
         }
         if (event != null
                 && (event instanceof KeyEvent && event.getID() == KeyEvent.KEY_RELEASED && itemType == searchField)
                 || (event instanceof ActionEvent && event.getID() == ActionEvent.ACTION_PERFORMED && itemType == filterBySearch)) {
             updateFilter();
         }
+    }
+    
+    /**
+     * Method is extracted from itemListenerAction.
+     * It handles the event when a literal is entered into the searchfield.
+     * Refactored: local variables renamed so that the code has a better readability. 
+     */
+    private void filterTableContents() {
+    	
+        String sSearchValue = searchField.getValueFromField();
+        if (sSearchValue != null && sSearchValue.length() > 0 && keys != null && items != null) {
+            sSearchValue = sSearchValue.toLowerCase();
+            Vector<String> sSplittedSearchValues = null;
+            boolean[] bDidFindValue = null;
+            if (sSearchValue.indexOf(" ") > 0) {
+                sSplittedSearchValues = EfaUtil.split(sSearchValue, ' ');
+                if (sSplittedSearchValues != null && sSplittedSearchValues.size() == 0) {
+                    sSplittedSearchValues = null;
+                } else {
+                    bDidFindValue = new boolean[sSplittedSearchValues.size()];
+                }
+            }
+            int rowFound = -1;
+            for (int iCurrentRow = 0; rowFound < 0 && iCurrentRow < keys.length; iCurrentRow++) {
+                // search in row iCurrentRow
+                for (int j = 0; bDidFindValue != null && j < bDidFindValue.length; j++) {
+                    bDidFindValue[j] = false; // matched parts of substring
+                }
+
+                TableItem[] row = items.get(keys[iCurrentRow]);
+                for (int iCurrentCol = 0; row != null && rowFound < 0 && iCurrentCol < row.length; iCurrentCol++) {
+                    // search in row i, column j
+                    String t = (row[iCurrentCol] != null ? row[iCurrentCol].toString() : null);
+                    t = (t != null ? t.toLowerCase() : null);
+                    if (t == null) {
+                        continue;
+                    }
+
+                    // match entire search string against column
+                    if (t.indexOf(sSearchValue) >= 0) {
+                        rowFound = iCurrentRow;
+                    }
+
+                    if (sSplittedSearchValues != null && rowFound < 0) {
+                        // match column agains substrings
+                        for (int k = 0; k < sSplittedSearchValues.size(); k++) {
+                            if (t.indexOf(sSplittedSearchValues.get(k)) >= 0) {
+                                bDidFindValue[k] = true;
+                            }
+                        }
+                    }
+                }
+                if (bDidFindValue != null && rowFound < 0) {
+                    rowFound = iCurrentRow;
+                    for (int j = 0; j < bDidFindValue.length; j++) {
+                        if (!bDidFindValue[j]) {
+                            rowFound = -1;
+                        }
+                    }
+                }
+            }
+            if (rowFound >= 0) {
+                int currentIdx = table.getCurrentRowIndex(rowFound);
+                if (currentIdx >= 0) {
+                    scrollToRow(currentIdx);
+                }
+            }
+        }
+        
     }
 
     protected void updateFilter() {
@@ -612,7 +623,8 @@ public class ItemTypeDataRecordTable extends ItemTypeTable implements IItemListe
                 if (r != null && (!r.getDeleted() || showDeleted)) {
                     if (filterFieldName == null || filterFieldValue == null
                             || filterFieldValue.equals(r.getAsString(filterFieldName))) {
-                        if (filterByAnyText == null || r.getAllFieldsAsSeparatedText().toLowerCase().indexOf(filterByAnyText) >= 0) {
+                    	// Check if field content matches to the searchtext. Also, check if the entry matches for a certain date.
+                    	if (filterByAnyText == null || r.getAllFieldsAsSeparatedText().toLowerCase().indexOf(filterByAnyText) >= 0 || filterFromToAppliesToDate(r, filterByAnyText)) {
                             data.add(r);
                         }
                     }
@@ -624,6 +636,19 @@ public class ItemTypeDataRecordTable extends ItemTypeTable implements IItemListe
         }
     }
 
+    /**
+     * Default implementation of the method which returns false for all tables which do not
+     * allow date-based filtering. Check derived classes of ItemTypeDataRecordTable which implement this method
+     * to find those tables which do.
+     * 
+     * @param theDataRecord
+     * @param filterValue 
+     * @return true if the filtervalue (as a date) applies to the datarecord
+     */
+    protected boolean filterFromToAppliesToDate(DataRecord theDataRecord, String filterValue) {
+    	return false;
+    }
+        
     public void actionPerformed(ActionEvent e) {
         itemListenerAction(this, e);
     }
@@ -666,5 +691,17 @@ public class ItemTypeDataRecordTable extends ItemTypeTable implements IItemListe
     public boolean isFilterSet() {
         filterBySearch.getValueFromGui();
         return filterBySearch.getValue();
+    }
+    
+    /**
+     * Use this method to programmatically activate the checkbox "filterbysearch" so that
+     * only the filtertext-matching items in the table are displayed.
+     * 
+     * @param value Value to which the internal variable is set
+     */
+    public void setIsFilterSet(Boolean value) {
+    	filterBySearch.setValue(value);
+    	updateFilter();
+    	updateData();
     }
 }

--- a/de/nmichael/efa/core/items/ItemTypeDataRecordTable.java
+++ b/de/nmichael/efa/core/items/ItemTypeDataRecordTable.java
@@ -621,13 +621,17 @@ public class ItemTypeDataRecordTable extends ItemTypeTable implements IItemListe
                     }
                 }
                 if (r != null && (!r.getDeleted() || showDeleted)) {
-                    if (filterFieldName == null || filterFieldValue == null
-                            || filterFieldValue.equals(r.getAsString(filterFieldName))) {
-                    	// Check if field content matches to the searchtext. Also, check if the entry matches for a certain date.
-                    	if (filterByAnyText == null || r.getAllFieldsAsSeparatedText().toLowerCase().indexOf(filterByAnyText) >= 0 || filterFromToAppliesToDate(r, filterByAnyText)) {
-                            data.add(r);
-                        }
-                    }
+
+                	if (!removeItemByCustomFilter(r)) {
+                	
+	                    if (filterFieldName == null || filterFieldValue == null
+	                            || filterFieldValue.equals(r.getAsString(filterFieldName))) {
+	                    	// Check if field content matches to the searchtext. Also, check if the entry matches for a certain date.
+	                    	if (filterByAnyText == null || r.getAllFieldsAsSeparatedText().toLowerCase().indexOf(filterByAnyText) >= 0 || filterFromToAppliesToDate(r, filterByAnyText)) {
+	                            data.add(r);
+	                        }
+	                    }
+                	}
                 }
                 key = it.getNext();
             }
@@ -648,7 +652,23 @@ public class ItemTypeDataRecordTable extends ItemTypeTable implements IItemListe
     protected boolean filterFromToAppliesToDate(DataRecord theDataRecord, String filterValue) {
     	return false;
     }
-        
+
+    /**
+     * Use this function to remove items from the table by using custom filters which apply
+     * to the special record type.
+     * 
+     * How to apply custom filters to itemTypeDataRecordTable:
+     * - modify the specialized class of DataListDialog.java to add a control panel above the table. 
+     *   The actionlistener shall then set a dedicated attribute in the specialized class of ItemTypeDataRecordTable.
+     * - override this function in the specialized class of ItemTypeDataRecordTable.
+     * 
+     * @param theDataRecord
+     * @return
+     */
+    protected boolean removeItemByCustomFilter(DataRecord theDataRecord) {
+    	return false;
+    }
+    
     public void actionPerformed(ActionEvent e) {
         itemListenerAction(this, e);
     }

--- a/de/nmichael/efa/data/types/DataTypeDate.java
+++ b/de/nmichael/efa/data/types/DataTypeDate.java
@@ -9,15 +9,15 @@
  */
 package de.nmichael.efa.data.types;
 
+import java.time.LocalTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
 import de.nmichael.efa.Daten;
 import de.nmichael.efa.core.config.EfaTypes;
-import static de.nmichael.efa.data.types.DataTypeDistance.KILOMETERS;
-import static de.nmichael.efa.data.types.DataTypeDistance.MILES;
 import de.nmichael.efa.util.EfaUtil;
 import de.nmichael.efa.util.International;
 import de.nmichael.efa.util.TMJ;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 
 public class DataTypeDate implements Cloneable, Comparable<DataTypeDate> {
 
@@ -148,6 +148,7 @@ public class DataTypeDate implements Cloneable, Comparable<DataTypeDate> {
     }
 
     public void ensureCorrectDate() {
+    	
         if (!isSet()) {
             return;
         }
@@ -158,8 +159,9 @@ public class DataTypeDate implements Cloneable, Comparable<DataTypeDate> {
         if (!fourdigit && year < 1900) {
             year += 1900;
         }
-        if (!fourdigit && year < 1920) {
-            year += 100;
+        // see efautil.correctDate() -> everything <1980 will be put to the next century.
+        if (!fourdigit && year < 1980) {
+            year += 100; 
         }
         if (month < 0 || month > 12) { // treat month==0 as "unset month" and don't correct it
             month = 1;
@@ -529,6 +531,31 @@ public class DataTypeDate implements Cloneable, Comparable<DataTypeDate> {
                 return International.getString("Sonntag");
         }
         return EfaTypes.TEXT_UNKNOWN;
+    }
+    
+    /**
+     * Converts the Java Weekday of the current instance to an EfaTypes weekday.
+     * 
+     * @return The string representing the value of EFA type of the day of the week
+     */
+    public String getWeekdayAsEfaType() {
+        switch (toCalendar().get(Calendar.DAY_OF_WEEK)) {
+	        case Calendar.MONDAY:
+	            return EfaTypes.TYPE_WEEKDAY_MONDAY;
+	        case Calendar.TUESDAY:
+	            return EfaTypes.TYPE_WEEKDAY_TUESDAY;
+	        case Calendar.WEDNESDAY:
+	            return EfaTypes.TYPE_WEEKDAY_WEDNESDAY;
+	        case Calendar.THURSDAY:
+	            return EfaTypes.TYPE_WEEKDAY_THURSDAY;
+	        case Calendar.FRIDAY:
+	            return EfaTypes.TYPE_WEEKDAY_FRIDAY;
+	        case Calendar.SATURDAY:
+	            return EfaTypes.TYPE_WEEKDAY_SATURDAY;
+	        case Calendar.SUNDAY:
+	            return EfaTypes.TYPE_WEEKDAY_SUNDAY;
+	    }
+        return EfaTypes.TEXT_UNKNOWN;	
     }
 
     public static String[] makeDistanceUnitValueArray() {

--- a/de/nmichael/efa/gui/dataedit/BoatDamageItemTypeDataRecordTable.java
+++ b/de/nmichael/efa/gui/dataedit/BoatDamageItemTypeDataRecordTable.java
@@ -11,6 +11,8 @@ import de.nmichael.efa.gui.util.TableItemHeader;
 
 public class BoatDamageItemTypeDataRecordTable extends ItemTypeDataRecordTable {
 
+	private Boolean showOpenDamagesOnly = true;
+	
 	public BoatDamageItemTypeDataRecordTable(String name, TableItemHeader[] tableHeader, StorageObject persistence,
 			long validAt, AdminRecord admin, String filterFieldName, String filterFieldValue, String[] actions,
 			int[] actionTypes, String[] actionIcons, IItemListenerDataRecordTable itemListenerActionTable, int type,
@@ -68,4 +70,24 @@ public class BoatDamageItemTypeDataRecordTable extends ItemTypeDataRecordTable {
 		}
 	}
 
+    protected boolean removeItemByCustomFilter(DataRecord theDataRecord) {
+
+    	if (this.showOpenDamagesOnly) {
+    		//item shall be removed if it is already fixed
+    		return ((BoatDamageRecord) theDataRecord).getFixed();//casting is safe here
+    	} else {
+    		return false;
+    	}
+    }
+	
+	public Boolean getShowOpenDamagesOnly() {
+		return showOpenDamagesOnly;
+	}
+
+	public void setShowOpenDamagesOnly(Boolean bShowOpenDamagesOnly) {
+		this.showOpenDamagesOnly = bShowOpenDamagesOnly;
+		// When the item is set, apply the filter...
+		updateData();
+		showValue(); //updateData alone won't suffice
+	}
 }

--- a/de/nmichael/efa/gui/dataedit/BoatDamageItemTypeDataRecordTable.java
+++ b/de/nmichael/efa/gui/dataedit/BoatDamageItemTypeDataRecordTable.java
@@ -1,0 +1,71 @@
+package de.nmichael.efa.gui.dataedit;
+
+import de.nmichael.efa.core.config.AdminRecord;
+import de.nmichael.efa.core.items.IItemListenerDataRecordTable;
+import de.nmichael.efa.core.items.ItemTypeDataRecordTable;
+import de.nmichael.efa.data.BoatDamageRecord;
+import de.nmichael.efa.data.storage.DataRecord;
+import de.nmichael.efa.data.storage.StorageObject;
+import de.nmichael.efa.data.types.DataTypeDate;
+import de.nmichael.efa.gui.util.TableItemHeader;
+
+public class BoatDamageItemTypeDataRecordTable extends ItemTypeDataRecordTable {
+
+	public BoatDamageItemTypeDataRecordTable(String name, TableItemHeader[] tableHeader, StorageObject persistence,
+			long validAt, AdminRecord admin, String filterFieldName, String filterFieldValue, String[] actions,
+			int[] actionTypes, String[] actionIcons, IItemListenerDataRecordTable itemListenerActionTable, int type,
+			String category, String description) {
+
+		super("TABLE", persistence.createNewRecord().getGuiTableHeader(), persistence, validAt, admin, filterFieldName,
+				filterFieldValue, // defaults are null
+				actions, actionTypes, actionIcons, // default actions: new, edit, delete
+				itemListenerActionTable, type, category, description);
+	}
+
+	// Diese Methode soll die Eingabe als Datum interpretieren,
+	// und prüfen, ob die Datensätze der Liste zu dem Datum passen.
+	protected boolean filterFromToAppliesToDate(DataRecord theDataRecord, String filterValue) {
+
+		if (filterValue == null) {
+			return false;
+		}
+
+		DataTypeDate curDate = DataTypeDate.parseDate(filterValue.trim());
+		if (!curDate.isSet()) {
+			// die Eingabe ist kein Datum. Damit können wir hier keine zutreffenden Zeilen
+			// ermitteln.
+			return false;
+		}
+
+		String theDateFrom = theDataRecord.getAsString(BoatDamageRecord.REPORTDATE);
+		String theDateTo = theDataRecord.getAsString(BoatDamageRecord.FIXDATE);
+
+		if ((theDateFrom == null)) {
+			return false;
+		} else {
+
+			DataTypeDate fromDate = DataTypeDate.parseDate(theDateFrom);
+			DataTypeDate toDate = null;
+
+			if ((theDateTo != null)) {
+				toDate = DataTypeDate.parseDate(theDateTo);
+				if ((fromDate.isSet() && toDate.isSet())) {
+
+					// true, wenn das eingegebene Datum ist zwischen den beiden Datumswerten ist
+					return (curDate.isAfterOrEqual(fromDate) && curDate.isBeforeOrEqual(toDate));
+
+				} else {
+					return false;
+				}
+			} else {
+				if (fromDate.isSet()) {
+					return (curDate.isAfterOrEqual(fromDate));
+				} else {
+					return false;
+				}
+			}
+
+		}
+	}
+
+}

--- a/de/nmichael/efa/gui/dataedit/BoatDamageListDialog.java
+++ b/de/nmichael/efa/gui/dataedit/BoatDamageListDialog.java
@@ -29,6 +29,8 @@ import javax.swing.*;
 
 // @i18n complete
 public class BoatDamageListDialog extends DataListDialog {
+	
+	protected ItemTypeBoolean showOpenDamagesOnly;
 
     public BoatDamageListDialog(Frame parent, AdminRecord admin) {
         super(parent, International.getString("Bootsschäden"), Daten.project.getBoatDamages(false), 0, admin);
@@ -56,6 +58,10 @@ public class BoatDamageListDialog extends DataListDialog {
             this.filterFieldValue = boatId.toString();
         }
         super.sortByColumn = 4;
+        
+        // Table update: Minimum column widths of 95 pix for the timestamp colums 
+        // so they show at least the date part fully readable. 
+        this.minColumnWidths = new int[] {110,0,100,100,12};  
     }
 
     public void keyAction(ActionEvent evt) {
@@ -147,4 +153,37 @@ public class BoatDamageListDialog extends DataListDialog {
 		//show only matching items by default in BoatDamageListDialog 
 		table.setIsFilterSet(true);
 	}
+	
+    protected void iniControlPanel() {
+    	// we want to put an additional element after the control panel
+    	super.iniControlPanel();
+    	this.iniBoatDamageListFilter();
+    }
+	
+	private void iniBoatDamageListFilter() {
+		JPanel myControlPanel= new JPanel();
+    	
+    	showOpenDamagesOnly = new ItemTypeBoolean("SHOW_ACTIVE_DAMAGES_ONLY",
+                true,
+                IItemType.TYPE_PUBLIC, "", International.getString("nur offene Bootsschäden"));
+    	showOpenDamagesOnly.setPadding(0, 0, 0, 0);
+    	showOpenDamagesOnly.displayOnGui(this, myControlPanel, 0, 0);
+    	showOpenDamagesOnly.registerItemListener(this);
+        mainPanel.add(myControlPanel, BorderLayout.NORTH);
+	}    
+	
+    public void itemListenerAction(IItemType itemType, AWTEvent event) {
+    	
+    	// handle our special filter for active damages, else use default item handler
+    	if (itemType==showOpenDamagesOnly) {
+    		
+    		 if (event.getID() == ActionEvent.ACTION_PERFORMED) {
+    			 showOpenDamagesOnly.getValueFromGui();
+    			 ((BoatDamageItemTypeDataRecordTable) table).setShowOpenDamagesOnly(showOpenDamagesOnly.getValue());	 
+    		 }
+    		
+    	} else {
+    		super.itemListenerAction(itemType, event);
+    	}
+    }
 }

--- a/de/nmichael/efa/gui/dataedit/BoatDamageListDialog.java
+++ b/de/nmichael/efa/gui/dataedit/BoatDamageListDialog.java
@@ -131,5 +131,20 @@ public class BoatDamageListDialog extends DataListDialog {
                 return false;
         }
     }
-
+    
+	protected void createSpecificItemTypeRecordTable() {
+        table = new BoatDamageItemTypeDataRecordTable("TABLE",
+                persistence.createNewRecord().getGuiTableHeader(),
+                persistence, validAt, admin,
+                filterFieldName, filterFieldValue, // defaults are null
+                actionText, actionType, actionImage, // default actions: new, edit, delete
+                this,
+                IItemType.TYPE_PUBLIC, "BASE_CAT", getTitle());
+	}
+	
+	protected void iniDialog() throws Exception {
+		super.iniDialog();
+		//show only matching items by default in BoatDamageListDialog 
+		table.setIsFilterSet(true);
+	}
 }

--- a/de/nmichael/efa/gui/dataedit/BoatReservationItemTypeDataRecordTable.java
+++ b/de/nmichael/efa/gui/dataedit/BoatReservationItemTypeDataRecordTable.java
@@ -1,0 +1,83 @@
+package de.nmichael.efa.gui.dataedit;
+
+import de.nmichael.efa.core.config.AdminRecord;
+import de.nmichael.efa.core.items.IItemListenerDataRecordTable;
+import de.nmichael.efa.core.items.ItemTypeDataRecordTable;
+import de.nmichael.efa.data.storage.DataRecord;
+import de.nmichael.efa.data.storage.StorageObject;
+import de.nmichael.efa.data.types.DataTypeDate;
+import de.nmichael.efa.gui.util.TableItemHeader;
+import de.nmichael.efa.data.BoatReservationRecord;
+
+public class BoatReservationItemTypeDataRecordTable extends ItemTypeDataRecordTable {
+
+	public BoatReservationItemTypeDataRecordTable(String name, TableItemHeader[] tableHeader, StorageObject persistence,
+			long validAt, AdminRecord admin, String filterFieldName, String filterFieldValue, String[] actions,
+			int[] actionTypes, String[] actionIcons, IItemListenerDataRecordTable itemListenerActionTable, int type,
+			String category, String description) {
+		super("TABLE", persistence.createNewRecord().getGuiTableHeader(), persistence, validAt, admin, filterFieldName,
+				filterFieldValue, // defaults are null
+				actions, actionTypes, actionIcons, // default actions: new, edit, delete
+				itemListenerActionTable, type, category, description);
+	}
+
+	// Diese Methode soll die Eingabe als Datum interpretieren,
+	// und prüfen, ob die Datensätze der Liste zu dem Datum passen.
+	// dies ist erforderlich für die Bootsreservierung - damit bei der Suche nach
+	// einem Datum
+	// auch Reservierungen gefunden werden, deren Zeitraum das eingegebene Datum
+	// abdeckt.
+	protected boolean filterFromToAppliesToDate(DataRecord theDataRecord, String filterValue) {
+
+		//
+		if (filterValue == null) {
+			return false;
+
+		}
+
+		DataTypeDate curDate = DataTypeDate.parseDate(filterValue.trim());
+		if (!curDate.isSet()) {
+			// die Eingabe ist kein Datum. Damit können wir hier keine zutreffenden Zeilen
+			// ermitteln.
+			return false;
+		}
+
+		if (theDataRecord.getAsString(BoatReservationRecord.TYPE).equals(BoatReservationRecord.TYPE_ONETIME)) {
+
+			String theDateFrom = theDataRecord.getAsString(BoatReservationRecord.DATEFROM);
+			String theDateTo = theDataRecord.getAsString(BoatReservationRecord.DATETO);
+
+			if ((theDateFrom == null) || (theDateTo == null)) {
+				return false;
+			} else {
+
+				DataTypeDate fromDate = DataTypeDate.parseDate(theDateFrom);
+				DataTypeDate toDate = DataTypeDate.parseDate(theDateTo);
+
+				if ((fromDate.isSet() && toDate.isSet())) {
+
+					// true, wenn das eingegebene Datum ist zwischen den beiden Datumswerten der
+					// Reservierung ist
+
+					return (curDate.isAfterOrEqual(fromDate) && curDate.isBeforeOrEqual(toDate));
+
+				} else {
+					return false;
+				}
+			}
+
+		} else {
+			// weekly reservation -
+			// wir ermitteln den Wochentag aus dem eingegebenen Datum, und schauen, 
+			// ob es zu diesem Wochentag eine Reservierung gibt.
+			
+			String strWeekday = curDate.getWeekdayAsEfaType();
+			String strWeekdayFromRecord = theDataRecord.getAsString(BoatReservationRecord.DAYOFWEEK);
+			
+			return strWeekday.equals(strWeekdayFromRecord);
+			
+		}
+
+	}
+
+}

--- a/de/nmichael/efa/gui/dataedit/BoatReservationListDialog.java
+++ b/de/nmichael/efa/gui/dataedit/BoatReservationListDialog.java
@@ -164,4 +164,19 @@ public class BoatReservationListDialog extends DataListDialog {
             return null;
         }
     }
+	protected void createSpecificItemTypeRecordTable() {
+        table = new BoatReservationItemTypeDataRecordTable("TABLE",
+                persistence.createNewRecord().getGuiTableHeader(),
+                persistence, validAt, admin,
+                filterFieldName, filterFieldValue, // defaults are null
+                actionText, actionType, actionImage, // default actions: new, edit, delete
+                this,
+                IItemType.TYPE_PUBLIC, "BASE_CAT", getTitle());
+	}
+	
+	protected void iniDialog() throws Exception {
+		super.iniDialog();
+		//show only matching items by default in BoatDamageListDialog 
+		table.setIsFilterSet(true);
+	}
 }

--- a/de/nmichael/efa/gui/dataedit/DataListDialog.java
+++ b/de/nmichael/efa/gui/dataedit/DataListDialog.java
@@ -213,14 +213,10 @@ public abstract class DataListDialog extends BaseDialog implements IItemListener
             mainTablePanel.add(filterName, BorderLayout.NORTH);
             mainTablePanel.setBorder(new EmptyBorder(10,0,0,0));
         }
-
-        table = new ItemTypeDataRecordTable("TABLE",
-                persistence.createNewRecord().getGuiTableHeader(),
-                persistence, validAt, admin,
-                filterFieldName, filterFieldValue, // defaults are null
-                actionText, actionType, actionImage, // default actions: new, edit, delete
-                this,
-                IItemType.TYPE_PUBLIC, "BASE_CAT", getTitle());
+        
+        // Instanciates the table variable with the specific type which is needed. 
+        createSpecificItemTypeRecordTable();
+        
         table.setSorting(sortByColumn, sortAscending);
         table.setFontSize(tableFontSize);
         table.setMarkedCellColor(markedCellColor);
@@ -253,6 +249,21 @@ public abstract class DataListDialog extends BaseDialog implements IItemListener
         setRequestFocus(table);
         this.validate();
     }
+
+    /**
+     * Instanciates the table variable to the specific subtype of ItemTypeDataRecord that is needed
+     * by the subclass of DataListDialog.
+     * Default implementation creates a standard ItemTypeDataRecordTable.
+     */
+	protected void createSpecificItemTypeRecordTable() {
+		table = new ItemTypeDataRecordTable("TABLE",
+                persistence.createNewRecord().getGuiTableHeader(),
+                persistence, validAt, admin,
+                filterFieldName, filterFieldValue, // defaults are null
+                actionText, actionType, actionImage, // default actions: new, edit, delete
+                this,
+                IItemType.TYPE_PUBLIC, "BASE_CAT", getTitle());
+	}
 
     protected void iniControlPanel() {
         if (persistence != null && persistence.data().getMetaData().isVersionized()) {

--- a/de/nmichael/efa/gui/dataedit/SessionGroupItemTypeDataRecordTable.java
+++ b/de/nmichael/efa/gui/dataedit/SessionGroupItemTypeDataRecordTable.java
@@ -1,0 +1,60 @@
+package de.nmichael.efa.gui.dataedit;
+
+import de.nmichael.efa.core.config.AdminRecord;
+import de.nmichael.efa.core.items.IItemListenerDataRecordTable;
+import de.nmichael.efa.core.items.ItemTypeDataRecordTable;
+import de.nmichael.efa.data.SessionGroupRecord;
+import de.nmichael.efa.data.storage.DataRecord;
+import de.nmichael.efa.data.storage.StorageObject;
+import de.nmichael.efa.data.types.DataTypeDate;
+import de.nmichael.efa.gui.util.TableItemHeader;
+
+public class SessionGroupItemTypeDataRecordTable extends ItemTypeDataRecordTable {
+	public SessionGroupItemTypeDataRecordTable(String name, TableItemHeader[] tableHeader, StorageObject persistence,
+			long validAt, AdminRecord admin, String filterFieldName, String filterFieldValue, String[] actions,
+			int[] actionTypes, String[] actionIcons, IItemListenerDataRecordTable itemListenerActionTable, int type,
+			String category, String description) {
+
+		super("TABLE", persistence.createNewRecord().getGuiTableHeader(), persistence, validAt, admin, filterFieldName,
+				filterFieldValue, // defaults are null
+				actions, actionTypes, actionIcons, // default actions: new, edit, delete
+				itemListenerActionTable, type, category, description);
+	}
+
+	// Diese Methode soll die Eingabe als Datum interpretieren,
+	// und prüfen, ob die Datensätze der Liste zu dem Datum passen.
+	protected boolean filterFromToAppliesToDate(DataRecord theDataRecord, String filterValue) {
+
+		if (filterValue == null) {
+			return false;
+		}
+
+		DataTypeDate curDate = DataTypeDate.parseDate(filterValue.trim());
+		if (!curDate.isSet()) {
+			// die Eingabe ist kein Datum. Damit können wir hier keine zutreffenden Zeilen
+			// ermitteln.
+			return false;
+		}
+
+		String theDateFrom = theDataRecord.getAsString(SessionGroupRecord.STARTDATE);
+		String theDateTo = theDataRecord.getAsString(SessionGroupRecord.ENDDATE);
+
+		if ((theDateFrom == null) || (theDateTo == null)) {
+			return false;
+		} else {
+
+			DataTypeDate fromDate = DataTypeDate.parseDate(theDateFrom);
+			DataTypeDate toDate = DataTypeDate.parseDate(theDateTo);
+
+			if ((fromDate.isSet() && toDate.isSet())) {
+
+				// true, wenn das eingegebene Datum ist zwischen den beiden Datumswerten ist
+
+				return (curDate.isAfterOrEqual(fromDate) && curDate.isBeforeOrEqual(toDate));
+
+			} else {
+				return false;
+			}
+		}
+	}
+}

--- a/de/nmichael/efa/gui/dataedit/SessionGroupListDialog.java
+++ b/de/nmichael/efa/gui/dataedit/SessionGroupListDialog.java
@@ -91,6 +91,8 @@ public class SessionGroupListDialog extends DataListDialog {
         if (selectedSessionGroupId != null) {
             table.selectValue(selectedSessionGroupId.toString());
         }
+        //by default only display matching elements in the table
+        table.setIsFilterSet(true);
     }
 
     public void keyAction(ActionEvent evt) {
@@ -133,4 +135,13 @@ public class SessionGroupListDialog extends DataListDialog {
         return selectedRecord;
     }
     
+	protected void createSpecificItemTypeRecordTable() {
+        table = new SessionGroupItemTypeDataRecordTable("TABLE",
+                persistence.createNewRecord().getGuiTableHeader(),
+                persistence, validAt, admin,
+                filterFieldName, filterFieldValue, // defaults are null
+                actionText, actionType, actionImage, // default actions: new, edit, delete
+                this,
+                IItemType.TYPE_PUBLIC, "BASE_CAT", getTitle());
+	}
 }

--- a/de/nmichael/efa/gui/dataedit/StatisticsItemTypeDataRecordTable.java
+++ b/de/nmichael/efa/gui/dataedit/StatisticsItemTypeDataRecordTable.java
@@ -1,0 +1,62 @@
+package de.nmichael.efa.gui.dataedit;
+
+import de.nmichael.efa.core.config.AdminRecord;
+import de.nmichael.efa.core.items.IItemListenerDataRecordTable;
+import de.nmichael.efa.core.items.ItemTypeDataRecordTable;
+import de.nmichael.efa.data.StatisticsRecord;
+import de.nmichael.efa.data.storage.DataRecord;
+import de.nmichael.efa.data.storage.StorageObject;
+import de.nmichael.efa.data.types.DataTypeDate;
+import de.nmichael.efa.gui.util.TableItemHeader;
+
+public class StatisticsItemTypeDataRecordTable extends ItemTypeDataRecordTable {
+
+	public StatisticsItemTypeDataRecordTable(String name, TableItemHeader[] tableHeader, StorageObject persistence,
+			long validAt, AdminRecord admin, String filterFieldName, String filterFieldValue, String[] actions,
+			int[] actionTypes, String[] actionIcons, IItemListenerDataRecordTable itemListenerActionTable, int type,
+			String category, String description) {
+
+		super("TABLE", persistence.createNewRecord().getGuiTableHeader(), persistence, validAt, admin, filterFieldName,
+				filterFieldValue, // defaults are null
+				actions, actionTypes, actionIcons, // default actions: new, edit, delete
+				itemListenerActionTable, type, category, description);
+	}
+
+	// Diese Methode soll die Eingabe als Datum interpretieren,
+	// und prüfen, ob die Datensätze der Liste zu dem Datum passen.
+	protected boolean filterFromToAppliesToDate(DataRecord theDataRecord, String filterValue) {
+
+		if (filterValue == null) {
+			return false;
+		}
+
+		DataTypeDate curDate = DataTypeDate.parseDate(filterValue.trim());
+		if (!curDate.isSet()) {
+			// die Eingabe ist kein Datum. Damit können wir hier keine zutreffenden Zeilen
+			// ermitteln.
+			return false;
+		}
+
+		String theDateFrom = theDataRecord.getAsString(StatisticsRecord.DATEFROM);
+		String theDateTo = theDataRecord.getAsString(StatisticsRecord.DATETO);
+
+		if ((theDateFrom == null) || (theDateTo == null)) {
+			return false;
+		} else {
+
+			DataTypeDate fromDate = DataTypeDate.parseDate(theDateFrom);
+			DataTypeDate toDate = DataTypeDate.parseDate(theDateTo);
+
+			if ((fromDate.isSet() && toDate.isSet())) {
+
+				// true, wenn das eingegebene Datum ist zwischen den beiden Datumswerten ist
+
+				return (curDate.isAfterOrEqual(fromDate) && curDate.isBeforeOrEqual(toDate));
+
+			} else {
+				return false;
+			}
+		}
+	}
+
+}

--- a/de/nmichael/efa/gui/dataedit/StatisticsListDialog.java
+++ b/de/nmichael/efa/gui/dataedit/StatisticsListDialog.java
@@ -12,6 +12,7 @@ package de.nmichael.efa.gui.dataedit;
 
 import de.nmichael.efa.*;
 import de.nmichael.efa.core.config.AdminRecord;
+import de.nmichael.efa.core.items.IItemType;
 import de.nmichael.efa.core.items.ItemTypeDataRecordTable;
 import de.nmichael.efa.data.*;
 import de.nmichael.efa.data.storage.*;
@@ -109,6 +110,8 @@ public class StatisticsListDialog extends DataListDialog {
     protected void iniDialog() throws Exception {
         super.iniDialog();
         table.setDefaultActionForDoubleclick(ACTION_CREATESTATISTICS);
+        // by default show only matching elements in the table
+        table.setIsFilterSet(true);
         if (admin == null) {
             table.setVisibleSearchPanel(false);
         }
@@ -156,4 +159,14 @@ public class StatisticsListDialog extends DataListDialog {
         }
         return new StatisticsEditDialog(parent, (StatisticsRecord)record, newRecord, admin);
     }
+    
+	protected void createSpecificItemTypeRecordTable() {
+        table = new StatisticsItemTypeDataRecordTable("TABLE",
+                persistence.createNewRecord().getGuiTableHeader(),
+                persistence, validAt, admin,
+                filterFieldName, filterFieldValue, // defaults are null
+                actionText, actionType, actionImage, // default actions: new, edit, delete
+                this,
+                IItemType.TYPE_PUBLIC, "BASE_CAT", getTitle());
+	}
 }


### PR DESCRIPTION
Branch is an addendum to EFA_0017_FILTER_BOATRESERVATIONS_BY_DATE_REPLAY

What it does
- Boat damage list dialog gets a new filter checkbox on top
- "show only open boat damages"
- checked by default

Technical changes
- ItemTypeDataRecordTable.java
- updateData() only add items which apply to text filter, if they are not already removed by an custom filter
- added a new protected function to filter by custom filter which is to be overwritten by subclasses

- BoatDamageItemTypeDataRecordTable.java
- support new property to filter for open damages

- BoatDamageListDialog.java
- add new checkbox below the control panel
- when checkbox state is changed, update the table

- no update to efa_de.properties neccessary