### PR TITLE
Avoid duplicate automplete suggestions

### DIFF
--- a/de/nmichael/efa/gui/EfaBaseFrame.java
+++ b/de/nmichael/efa/gui/EfaBaseFrame.java
@@ -3405,9 +3405,8 @@ public class EfaBaseFrame extends BaseDialog implements IItemListener {
                         updateBoatStatus(true, MODE_BOATHOUSE_FINISH);
                         saveEntry();
                         navigateInLogbook(0);
+                        autoCompleteListPersons.reset();
                     }
-                } else {
-                    iniGuiMain();
                 }
             }
             if (item == saveButton) {
@@ -4776,6 +4775,7 @@ public class EfaBaseFrame extends BaseDialog implements IItemListener {
         if (mode != EfaBaseFrame.MODE_BOATHOUSE_ABORT) {
             this.setVisible(false);
             Dialog.frameClosed(this);
+            autoCompleteListPersons.reset();
         }
         efaBoathouseFrame.showEfaBoathouseFrame(efaBoathouseAction, currentRecord);
     }

--- a/de/nmichael/efa/gui/EfaBaseFrame.java
+++ b/de/nmichael/efa/gui/EfaBaseFrame.java
@@ -3406,6 +3406,8 @@ public class EfaBaseFrame extends BaseDialog implements IItemListener {
                         saveEntry();
                         navigateInLogbook(0);
                     }
+                } else {
+                    iniGuiMain();
                 }
             }
             if (item == saveButton) {

--- a/de/nmichael/efa/gui/EfaBaseFrame.java
+++ b/de/nmichael/efa/gui/EfaBaseFrame.java
@@ -577,7 +577,7 @@ public class EfaBaseFrame extends BaseDialog implements IItemListener {
         cox.setFieldSize(200, 19);
         cox.setLabelGrid(1, GridBagConstraints.EAST, GridBagConstraints.NONE);
         cox.setFieldGrid(2, GridBagConstraints.WEST, GridBagConstraints.NONE);
-        cox.setAutoCompleteData(autoCompleteListPersons);
+        cox.setAutoCompleteData(autoCompleteListPersons, true);
         cox.setChecks(true, true);
         cox.setBackgroundColorWhenFocused(Daten.efaConfig.getValueEfaDirekt_colorizeInputField() ? Color.yellow : null);
         cox.displayOnGui(this, mainInputPanel, 0, 4);
@@ -594,7 +594,7 @@ public class EfaBaseFrame extends BaseDialog implements IItemListener {
             crew[j].setFieldSize(200, 19);
             crew[j].setLabelGrid(1, GridBagConstraints.EAST, GridBagConstraints.NONE);
             crew[j].setFieldGrid((left ? 2 : 3), GridBagConstraints.WEST, GridBagConstraints.NONE);
-            crew[j].setAutoCompleteData(autoCompleteListPersons);
+            crew[j].setAutoCompleteData(autoCompleteListPersons, true);
             crew[j].setChecks(true, true);
             crew[j].setBackgroundColorWhenFocused(Daten.efaConfig.getValueEfaDirekt_colorizeInputField() ? Color.yellow : null);
             crew[j].displayOnGui(this, mainInputPanel, (left ? 0 : 4), 5 + j%4);

--- a/de/nmichael/efa/gui/util/AutoCompleteList.java
+++ b/de/nmichael/efa/gui/util/AutoCompleteList.java
@@ -35,7 +35,7 @@ public class AutoCompleteList {
     private long efaConfigSCN = -1;
     private long validFrom = -1;
     private long validUntil = Long.MAX_VALUE;
-    private Vector<String> dataVisible = new Vector<String>();;
+    private Vector<String> dataVisible = new Vector<String>();
     private Hashtable<String,ValidInfo> name2valid = new Hashtable<String,ValidInfo>();
     private Hashtable<String,String> lower2realVisible = new Hashtable<String,String>();;
     private Hashtable<String,String> lower2realInvisible = new Hashtable<String,String>();;
@@ -523,11 +523,18 @@ public class AutoCompleteList {
         return v;
     }
 
+    public void reset() {
+        dataVisible = new Vector<String>();
+        dataVisible.addAll(name2valid.keySet());
+        sort();
+        lastPrefix = null;
+        pos = 0;
+    }
+
     public static void main(String[] args) {
         Vector<String> v = getPermutations("a b c", 7);
         for (int i=0; i<v.size(); i++) {
             System.out.println(v.get(i));
         }
     }
-    
 }


### PR DESCRIPTION
This PR avoids duplicate suggestions when starting a new session. This might be the case if the crew consists of people sharing the lastname.

![image](https://user-images.githubusercontent.com/1544760/147489553-b6422e03-eab1-40af-8d6c-1883026b7c22.png)

On master the same user is suggested over and over:
![image](https://user-images.githubusercontent.com/1544760/148149352-31074a0a-f7e9-40f5-96b0-31f4136a99d5.png)


Caveat:
This change affects only one dialog. If `John Doe` is already on a Boat in another session, he is still suggested.

Edit:
I added some bugfixes to reset the autocomplete state properly. This seems to work most of the time. Sometimes I cannot select suggestions (there might be still some bugs left). For now I cannot figure out what the cause is here.