### PR TITLE
Quick entry of new persons detects association name

### DIFF
--- a/de/nmichael/efa/gui/EfaBaseFrame.java
+++ b/de/nmichael/efa/gui/EfaBaseFrame.java
@@ -1974,6 +1974,11 @@ public class EfaBaseFrame extends BaseDialog implements IItemListener {
                 r.setNameAffix(name[2]);
                 anyNameSet = true;
             }
+            if (name != null && name[3] != null) {
+            	r.setAssocitation(name[3]);
+            	anyNameSet = true;
+            }
+            
             if (!anyNameSet && s != null) {
                 r.setFirstName(s);
             }


### PR DESCRIPTION
See https://github.com/nicmichael/efa/issues/23

When starting a new session, and enter a new person's name, the new syntax is
So the correct pattern for entering such a name should be

    Lastname, Firstname (Nameaddon) [NameOfAssociation]
    respectively
    Firstname Lastname (Nameaddon) [NameOfAssociation]

so that the name of the association is detected.
Also, the quick entry dialog contains the field for the Association, so that it can be changed (e.g. because of typos) before saving the entry.