### PR TITLE
Refactoring of EFA->EFB Sync

### DIFF
--- a/de/nmichael/efa/cli/MenuBase.java
+++ b/de/nmichael/efa/cli/MenuBase.java
@@ -10,10 +10,12 @@
 
 package de.nmichael.efa.cli;
 
+import java.util.Stack;
+import java.util.StringTokenizer;
+import java.util.Vector;
+
 import de.nmichael.efa.Daten;
 import de.nmichael.efa.util.EfaUtil;
-import java.util.Stack;
-import java.util.Vector;
 
 public abstract class MenuBase {
 
@@ -75,5 +77,23 @@ public abstract class MenuBase {
         }
         return -1; // to be handled by subclass
     }
-
+        
+    protected String removeOptionsFromArgs(String args) {
+        if (args!= null && !args.isEmpty()) {
+	    	StringBuilder sb = new StringBuilder();
+	        StringTokenizer tok = new StringTokenizer(args, " ");
+	        if (tok.countTokens() == 0) {
+	            return args;
+	        }
+	        while (tok.hasMoreTokens()) {
+	            String s = tok.nextToken().trim();
+	            if (!s.startsWith("-")) {
+	                sb.append( (sb.length() > 0 ? " " : "") + s);
+	            }
+	        }
+	        return sb.toString();
+        } else {
+        	return "";
+        }
+    }
 }

--- a/de/nmichael/efa/data/sync/KanuEfbStatistics.java
+++ b/de/nmichael/efa/data/sync/KanuEfbStatistics.java
@@ -1,0 +1,170 @@
+package de.nmichael.efa.data.sync;
+
+class KanuEfbStatistics {
+
+    private long requestCnt = 0;
+	private long totalTripCnt=0;
+    private long nonCanoeingTripCnt=0;
+    private long unfinishedTripCnt=0;
+    private long tooEarlyTripCnt=0;
+    private long alreadySyncedTripCnt=0;
+    private long nonSupportedBoatTypeTripCnt=0;
+    private long updatedTripCnt=0;
+    private long syncTripCnt=0;
+    private long personWithoutEFBIDTripCnt=0;
+    private long emptyBoatRecordTripCnt=0;
+	
+    
+    public  KanuEfbStatistics (long thetotalTripCount ) {
+    	totalTripCnt = thetotalTripCount;
+    }
+    
+    public void incrementNonCanoeingTripCntIfTrue(boolean value) {
+    	if (value) {nonCanoeingTripCnt++;}
+    }
+ 
+    public void incrementUnfinishedTripCntIfTrue(boolean value) {
+    	if (value) {unfinishedTripCnt ++;}
+    }
+    
+    public void incrementTooEarlyTripCntIfTrue(boolean value) {
+    	if (value) {tooEarlyTripCnt++;}
+    }
+    
+    public void incrementAlreadySyncedTripCntIfTrue(boolean value) {
+    	if (value) {alreadySyncedTripCnt++;}
+    }
+
+    public void incrementNonSupportedBoatTypeTriCntIfTrue(boolean value) {
+    	if (value) {nonSupportedBoatTypeTripCnt++;}
+    }
+    
+    public void incrementUpdatedtripCntIfTrue(boolean value) {
+    	if (value) {updatedTripCnt++;}
+    }
+    
+    public void incrementSyncTripCntIfTrue(boolean value) {
+    	if (value) {syncTripCnt++;}
+    }
+
+    public void incrementPersonWithoutEFBIDTripCntIfTrue(boolean value) {
+    	if (value) {personWithoutEFBIDTripCnt++;}
+    }
+    
+    public void incrementEmptyBoatRecordTripCntIfTrue(boolean value) {
+    	if (value) {emptyBoatRecordTripCnt++;}
+    }
+    
+    public void incrementRequestCnt() {
+    	requestCnt++;
+    }
+    
+    public long getRequestCnt() {
+		return requestCnt;
+	}
+
+
+	public void setRequestCnt(long requestCnt) {
+		this.requestCnt = requestCnt;
+	}
+
+
+	public long getTotalTripCnt() {
+		return totalTripCnt;
+	}
+
+
+	public void setTotalTripCnt(long totalTripCnt) {
+		this.totalTripCnt = totalTripCnt;
+	}
+
+
+	public long getNonCanoeingTripCnt() {
+		return nonCanoeingTripCnt;
+	}
+
+
+	public void setNonCanoeingTripCnt(long nonCanoeingTripCnt) {
+		this.nonCanoeingTripCnt = nonCanoeingTripCnt;
+	}
+
+
+	public long getUnfinishedTripCnt() {
+		return unfinishedTripCnt;
+	}
+
+
+	public void setUnfinishedTripCnt(long unfinishedTripCnt) {
+		this.unfinishedTripCnt = unfinishedTripCnt;
+	}
+
+
+	public long getTooEarlyTripCnt() {
+		return tooEarlyTripCnt;
+	}
+
+
+	public void setTooEarlyTripCnt(long tooEarlyTripCnt) {
+		this.tooEarlyTripCnt = tooEarlyTripCnt;
+	}
+
+
+	public long getAlreadySyncedTripCnt() {
+		return alreadySyncedTripCnt;
+	}
+
+
+	public void setAlreadySyncedTripCnt(long alreadySyncedTripCnt) {
+		this.alreadySyncedTripCnt = alreadySyncedTripCnt;
+	}
+
+
+	public long getNonSupportedBoatTypeTripCnt() {
+		return nonSupportedBoatTypeTripCnt;
+	}
+
+
+	public void setNonSupportedBoatTypeTripCnt(long nonSupportedBoatTypeTripCnt) {
+		this.nonSupportedBoatTypeTripCnt = nonSupportedBoatTypeTripCnt;
+	}
+
+
+	public long getUpdatedTripCnt() {
+		return updatedTripCnt;
+	}
+
+
+	public void setUpdatedTripCnt(long updatedTripCnt) {
+		this.updatedTripCnt = updatedTripCnt;
+	}
+
+
+	public long getSyncTripCnt() {
+		return syncTripCnt;
+	}
+
+
+	public void setSyncTripCnt(long syncTripCnt) {
+		this.syncTripCnt = syncTripCnt;
+	}
+
+
+	public long getPersonWithoutEFBIDTripCnt() {
+		return personWithoutEFBIDTripCnt;
+	}
+
+
+	public void setPersonWithoutEFBIDTripCnt(long personWithoutEFBIDTripCnt) {
+		this.personWithoutEFBIDTripCnt = personWithoutEFBIDTripCnt;
+	}
+
+
+	public long getEmptyBoatRecordTripCnt() {
+		return emptyBoatRecordTripCnt;
+	}
+
+
+	public void setEmptyBoatRecordTripCnt(long emptyBoatRecordTripCnt) {
+		this.emptyBoatRecordTripCnt = emptyBoatRecordTripCnt;
+	}
+}

--- a/de/nmichael/efa/data/sync/KanuEfbSyncTask.java
+++ b/de/nmichael/efa/data/sync/KanuEfbSyncTask.java
@@ -6,33 +6,210 @@
  *
  * @author Nicolas Michael
  * @version 2
+ * 
+ * Update 06/2022 
+ * 
+ * Die Anmerkungen sind auf Deutsch, da dieser Code nur für die Synchronisation mit dem deutschen Kanu-EFB
+ * enutzt werden kann.
+ *   
+ * - SyncWaters and SyncBoats sind von der EFB-Schnittstelle nicht mehr unterstützt und daher entfallen.
+ *   EFB ignorierte die Daten, die über die Methoden gesendet wurden, und lieferte leere Antworten.
+ *   
+ * - SyncUsers ist wie in früheren Versionen von EFA nur eine "leere" Hülle.
+ *   Hier wurden in früheren Versionen keine Nutzerdaten übertragen, der entsprechende Nutzcode war in der 
+ *   Methode auskommentiert. Die Synchronisation EFA->EFB funktioniert trotzdem, da sich EFA ausschließlich 
+ *   auf die bei der Person eingetragenen Kanu-EFB-ID verlässt.
+ *    
+ *   SyncUsers wurde im aktuellen Arbeitsstand noch nicht aus dem Code entfernt, sondern wird evtl. in zukünftigen 
+ *   Versionen überarbeitet (in Abstimmung mit dem EFB-Team). Derzeit würde SyncUsers ein DSGVO-Problem
+ *   darstellen, denn die dahinter stehende Logik würde derzeit alle Personendaten ohne EFB-ID in das EFB übertragen,
+ *   und dort ggfs. stille Accounts anlegen - ohne dass die Person dazu zwingend ihr Einverständnis gegeben hätte.
+ *   Das gilt auch für Gäste des Vereins, die im EFA ihre Fahrten eintragen.
+ *   
+ * - kanuEfb_Fullsync - neuer EXPERT Konfigurationsparameter, default false
+ *   Hierüber kann der Anwender anfordern, dass EFA grundsätzlich alle Fahrten im Fahrtenbuch als Grundlage
+ *   für die Übermittlung an EFB nutzt. Ist der Parameter nicht gesetzt, werden nur neue oder aktualisierte
+ *   Fahrten für die Übermittlung genutzt.
+ *   
+ *   Das Setzen dieses Parameters ist (bedarfsweise) sinnvoll, wenn ein Clubmitglied nachträglich eine EFB-ID
+ *   eingetragen bekommt. Denn dann werden zwar klassischerweise alle Fahrten neu synchronisiert, bei denen
+ *   dieses Clubmitglied alleine im Boot gesessen hat. Hat das Clubmitglied aber bei einem mehrsitzigen Boot
+ *   eine Fahrt mitgemacht, dann wurde diese Fahrt nicht mehr als zu synchronisieren erkannt.
+ *   Durch Setzen dieses Parameters werden auch solche Mehr-Personen-Fahrten nachträglich mit synchronisiert.
+ *   
+ * - kanuEfB_SyncTripsAfterDate - neuer EXPORT Konfigurationsparameter, default 01.01.1970
+ *   EFA berücksichtigt nur Fahrten aus dem aktuellen Fahrtenbuch, deren Beginndatum größer oder 
+ *   gleich dem hier eingetragenen Datum sind.
+ *  
+ *   Beginnt man als Club erstmalig mit der Synchronisation des EFA-Fahrtenbuchs an EFB, so muss man
+ *   aufpassen, welchen Zeitraum das Fahrtenbuch abdeckt. Die Kanu-Saison geht vom 01.10. bis zum 30.09. des
+ *   Folgejahres. Wenn nun aber das EFA-Fahrtenbuch klassischerweise vom 01.01.-31.12. geht, kommen auch Fahrten
+ *   außerhalb der Saison bei der EFA-EFB-Synchronisation in Betracht. Dies ist nicht zwingend erwünscht.
+ *   
+ *   Da beim erstmaligen Start das EFA noch nie Fahrten in das EFB übertragen hat, sind alle Fahrten aus
+ *   dem Fahrtenbuch neue Fahrten. Und kommen daher für die Übertragung in das EFB in Betracht.
+ *   Hat ein Mitglied aber schon eigenständig das persönliche EFB-Fahrtenbuch gepflegt, und werden 
+ *   durch Eintragung einer efb-Kanu-ID für dieses Mitglied dessen Fahrten in das EFB übertragen, dann 
+ *   entstehen im EFB Fahrtdubletten, die das Mitglied selbst im EFB auflösen muss.
+ *   
+ *   Um dies bei der Einführung der EFA-EFB-Synchronisation zu verhindern, oder zumindest die Anzahl der 
+ *   doppelten Einträge zu beschränken, kann man hier dasjenige Datum eintragen, ab dem die Fahrten synchronisiert
+ *   werden sollen.
+ *  
+ * - kanuEfb_boatTypes - PUBLIC Konfigurationsparameter Default "Kanu-Bootstypen"
+ *   Dieser Parameter gibt an, auf welchem Bootstyp eine Fahrt hat stattfinden müssen, damit sie für eine
+ *   Synchronisation in das EFB in Betracht kommt.
+ *   
+ *   Dies ist nützlich für Vereine, die sowohl Kanu wie z.B. auch Rudern anbieten - und wo dann in das 
+ *   EFB-Fahrtenbuch ausschließlich Kanufahrten übertragen werden sollen.
+ *   
+ *   In früheren Versionen von EFA wurde dieser Parameter nicht gespeichert. Das Setzen ist aber erforderlich,
+ *   um neue Kanutypen wie z.B. das aufsteigende SUP zu unterstützen.
+ *   
+ *  - kanuEfb_tidyXML - EXPORT Konfigurationsparameter Default false
+ *    
+ *    Das EFB-Schulungssystem wird immer mal wieder in einen Debugmodus gesetzt.
+ *    Wann das passiert, darauf hat der Nutzer des EFB-Schulungs-System keinen Einfluss. 
+ *    Wenn der Debugmodus im EFB aktiv ist, dann funktioniert die Synchronisation der Fahrten aus EFA 
+ *    nicht und bricht ab. Dies stört bei der Entwicklung oder auch beim Test der Synchronisation von 
+ *    Vereinen auf dem Schulungssystem erheblich.
+ *    
+ *    Grund für den Abbruch: In diesem Debugmodus schickt das EFB bei der Antwort auf syncTrips() vor dem 
+ *    eigentlichen XML-Datenstrom weitere Texte, die die Verarbeitung durch EFA stören. 
+ *    Daher wurde tidyXML in getResponse eingebaut; die Bereinigung findet nur dann statt, 
+ *    wenn der Konfigurationsparameter für tidyXML TRUE ist.
+ *           
+ * - syncTrips 
+ *   - Gibt beim Start die drei Konfigurationsparameter aus.
+ *   - Gibt zum Abschluss eine Statistik aus, wieviele Fahrten den einzelnen Bedingungen für eine Synchronisation  
+ *     entsprechen. So ist für EFA-Admins besser nachvollziehbar, warum bestimmte Fahrten (nicht) in das EFB
+ *     übertragen wurden.
+ *   - Unterstützt nun tatsächlich einen wählbaren Differential-Modus für die Synchronisation
+ *     In früheren Versionen war dies zwar beabsichtigt, kam aber wegen einem Logik-Fehler nicht zum Tragen.
+ *   - Synchronisiert KEINE Fahrten
+ *   	- die zwar eine Start-Uhrzeit, aber keine End-Uhrzeit haben
+ *        Dies sind im EFA alle noch nicht beendeten Fahrten. Das EFB weist solche Fahrten mit einem Fehler ab.
+ *        Daher wurden diese Fahrten vom Synchronisationsversuch ausgeschlossen.
+ *      - die auf einem Motorboot oder Ergometer stattgefunden haben.
+ *        Dies ist unabhängig von der Konfiguration der Bootstypen, für die die Synchronisation explizit gewünscht ist.
+ *      - deren Startdatum < Konfigurationsparameter kanuEfB_SyncTripsAfterDate ist.
+ *      - bei denen keines der Crewmitglieder eine Kanu-EFB-ID hat.
+ *        (wird als INFO geloggt, wenn Verbose-Mode aktiv)
+ *      - bei denen das boot keinen Bootstyp hat (dann ist das Boot nicht in der Bootsliste, oder es ist dort nicht vollständig erfasst.
+ *        Der Bootstyp ist relevant, da man ja nur Boote mit bestimmten Typen synchronisieren will.
+ *        (wird als INFO geloggt, wenn Verbose-Mode aktiv).
+ *        
+ *    - speichert bei jeder synchronisierten Fahrt den Zeitstempel, bei dem die letzte erfolgreiche Synchronisation
+ *      stattgefunden hat.
+ *      
+ *    - kann keine gelöschten Fahrten aus dem EFB entfernen. 
+ *      Die EFB-Schnittstelle gäbe dies zwar her, aber EFA kann sich keine gelöschten Fahrten merken.
+ *      Daher können diese aus dem EFB auch nicht wieder entfernt werden.
+ *      Es gibt auch (noch) keinen Audit-Modus, in dem man die im EFB gespeicherten Fahrten abrufen
+ *      und gegen die im EFA gespeicherten Fahrten abgleichen könnte.
+ *      
+ *  - isCanoeBoatType(BoatRecord) 
+ *    wurde aus efaConfig in die EFB-Synchronisation verschoben, um aus efaConfig eine Abhängigkeit
+ *    zu BoatRecord zu vermeiden.
+ *    
+ *  - EFA CLI EFB Sync
+ *    - Parameter -verbose kann angegeben werden, um nicht synchronisierbare Fahrten als Info-Meldungen in das Log auszugeben.
+ *    
+ *      
+ *  Allgemeine Fragen und Antworten:
+ *  a) Muss man im EFB eine Bootsliste pflegen, oder im EFA die Kanu-EFB-ID für das Boot eintragen?
+ *     
+ *     Nein. Bei der Synchronisation werden die Bootsnamen im Klartext übersendet.    
+ *     In früheren Versionen von EFA war vorgesehen, dass die Kanu-EFB-ID für das Boot im Rahmen des 
+ *     Synchronisationsvorgang von EFA selbst automatisch übernommen wird.
+ *     
+ *     Das gleiche gilt für den Namen des Gewässers, der bei jeder Fahrtsynchronisation im Klartext
+ *     in das EFB übertragen wird.
+ *     
+ *  b) Welche Informationen muss man für Personen im EFA pflegen, damit diese bei einer Synchronisation
+ *     -> EFB berücksichtigt werden?
+ *     
+ *     Es ist für die aktuelle Version lediglich die Eintragung der EFB-ID für die Person erforderlich,
+ *     damit sie für die EFB-Synchronisation in Frage kommt. Fehlt diese EFB-ID, oder wird sie wieder entfernt,
+ *     werden keine neue Fahrten für die Person im EFA mehr in das EFB übertragen.
+ *     
+ *     Es findet bei der Synchronisation KEIN Abgleich gegen den Namen, Vornamen oder Geburtsdatum statt.
+ *     Dementsprechend ist es wichtig, bei der Eintragung der EFB-ID keine Fehler zu machen, oder 
+ *     die EFB-ID bei mehreren Personen zeitgleich einzutragen.
+ *     
+ *     Es ist empfehlenswert, für mögliche spätere Ausbaustufen der EFA->EFB Synchronisation 
+ *     trotzdem Name, Vorname und Geburtsdatum im EFA einzutragen.
+ *     
+ *  c) Das EFB zeigt auch eine EFB-ID für Personen an, die ein stilles EFB-Konto haben. 
+ *     Können auch Fahrten für solche Personen in das EFB übertragen werden?
+ *     
+ *     Nein. Man kann zwar die EFB-ID für diese stillen Konten im EFA bei der betreffenden Person eintragen,
+ *     und EFA wird versuchen, diese Fahrt zu synchronisieren. Diese Fahrt wird aber vom EFB mit einem 
+ *     Fehler abgewiesen.
  */
 
 package de.nmichael.efa.data.sync;
 
 // @i18n complete
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.CookieHandler;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+import java.net.CookieStore;
+import java.net.HttpCookie;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
-import org.xml.sax.*;
-import de.nmichael.efa.data.*;
-import de.nmichael.efa.data.storage.*;
-import de.nmichael.efa.util.*;
-import de.nmichael.efa.*;
-import de.nmichael.efa.core.config.AdminRecord;
-import de.nmichael.efa.core.config.EfaTypes;
-import de.nmichael.efa.data.types.DataTypeDate;
-import de.nmichael.efa.data.types.DataTypeList;
-import de.nmichael.efa.gui.EfaConfigDialog;
-import de.nmichael.efa.gui.ProgressDialog;
-import de.nmichael.efa.gui.BaseTabbedDialog;
-import de.nmichael.efa.gui.dataedit.ProjectEditDialog;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import javax.swing.JDialog;
+
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+
+import de.nmichael.efa.Daten;
+import de.nmichael.efa.core.config.AdminRecord;
+import de.nmichael.efa.core.config.EfaTypes;
+import de.nmichael.efa.data.BoatRecord;
+import de.nmichael.efa.data.Boats;
+import de.nmichael.efa.data.DestinationRecord;
+import de.nmichael.efa.data.Destinations;
+import de.nmichael.efa.data.Logbook;
+import de.nmichael.efa.data.LogbookRecord;
+import de.nmichael.efa.data.PersonRecord;
+import de.nmichael.efa.data.Persons;
+import de.nmichael.efa.data.ProjectRecord;
+import de.nmichael.efa.data.SessionGroupRecord;
+import de.nmichael.efa.data.Waters;
+import de.nmichael.efa.data.WatersRecord;
+import de.nmichael.efa.data.storage.DataKey;
+import de.nmichael.efa.data.storage.DataKeyIterator;
+import de.nmichael.efa.data.storage.IDataAccess;
+import de.nmichael.efa.data.types.DataTypeDate;
+import de.nmichael.efa.data.types.DataTypeList;
+import de.nmichael.efa.gui.BaseTabbedDialog;
+import de.nmichael.efa.gui.EfaConfigDialog;
+import de.nmichael.efa.gui.ProgressDialog;
+import de.nmichael.efa.gui.dataedit.ProjectEditDialog;
+import de.nmichael.efa.util.Dialog;
+import de.nmichael.efa.util.EfaUtil;
+import de.nmichael.efa.util.International;
+import de.nmichael.efa.util.LogString;
+import de.nmichael.efa.util.Logger;
+import de.nmichael.efa.util.ProgressTask;
 
 
 public class KanuEfbSyncTask extends ProgressTask {
@@ -51,11 +228,10 @@ public class KanuEfbSyncTask extends ProgressTask {
     private boolean loggedIn = false;
     private boolean successfulCompleted = false;
     private int countSyncUsers = 0;
-    private int countSyncBoats = 0;
-    private int countSyncWaters = 0;
     private int countSyncTrips = 0;
     private int countWarnings = 0;
     private int countErrors = 0;
+    private boolean verboseMode=false;
 
     TrustManager[] trustAllCerts = new TrustManager[]{
         new X509TrustManager() {
@@ -74,11 +250,12 @@ public class KanuEfbSyncTask extends ProgressTask {
         }
     };
 
-    public KanuEfbSyncTask(Logbook logbook, AdminRecord admin) {
+    public KanuEfbSyncTask(Logbook logbook, AdminRecord admin, boolean verbose) {
         super();
         this.admin = admin;
         getConfigValues();
         this.logbook = logbook;
+        this.verboseMode=verbose;
     }
 
     private void getConfigValues() {
@@ -157,6 +334,13 @@ public class KanuEfbSyncTask extends ProgressTask {
             }
         }
 
+        // Auf Schulungssystemen, wo im EFB der Debugmodus aktiv ist, 
+        // liefert die Response weitere (nicht verarbeitbare) Daten vor dem eigentlichen XML-Datenstrom.
+        // Abhängig von der Konfiguration bereinigen wir diese Daten.
+        if (Daten.efaConfig.getValueKanuEfb_TidyXML()) {
+        	in=tidyXML(in);
+        }
+        
         KanuEfbXmlResponse response = null;
         try {
             XMLReader parser = EfaUtil.getXMLReader();
@@ -174,10 +358,53 @@ public class KanuEfbSyncTask extends ProgressTask {
         if (Logger.isTraceOn(Logger.TT_SYNC) && response != null) {
             response.printAll();
         }
-
+        
         return response;
     }
 
+    /**
+     * On EFB training sites, sometimes debug mode is active. This enriches the XML response stream
+     * with some annoying HTML entities at the beginning, describing the response output.
+     * As this is not conform to any standards, EFB synchronisation fails when debug mode is active on the EFB training site.
+     * 
+     * This code simply ignores everything within the XML response stream which is located before the opening xml or ?xml tags.
+     *  
+     * @param in InputStream containing the XML response
+     * @return  InputStream with the pure XML response.
+     */
+    private BufferedInputStream tidyXML(BufferedInputStream in) {
+    	
+        StringBuilder sb= new StringBuilder(250);
+    	try {
+    		in.mark(DEBUG_MARK_SIZE); //memorize current position in stream
+	    	BufferedReader buf = new BufferedReader(new InputStreamReader(in));
+	        String s;
+	  
+	        boolean inXML=false;
+	        while ((s = buf.readLine()) != null) {
+	        	if (s.trim().toLowerCase().startsWith("<xml")||s.trim().toLowerCase().startsWith("<?xml")) {
+	        		inXML=true;
+	        	}
+	        	else {
+	        		inXML=inXML; // just for debug purposes
+	        	}
+	        	if (inXML) {
+	        		sb.append(s);
+	        	}
+	        }
+	        in.reset(); // and reset reading position to memorized position.
+    	} catch(Exception e) {
+            Logger.log(e);
+            if (Logger.isTraceOn(Logger.TT_SYNC)) {
+                logInfo(Logger.DEBUG, Logger.MSG_SYNC_SYNCDEBUG, "Exceptione:" + e.toString());
+            }
+            return in;
+        }
+
+        return new BufferedInputStream(new ByteArrayInputStream(sb.toString().getBytes(StandardCharsets.UTF_8)));
+        
+    }
+    
     private boolean login() {
         try {
             loggedIn = false;
@@ -203,12 +430,12 @@ public class KanuEfbSyncTask extends ProgressTask {
             }
             String projectName = EfaUtil.escapeHtmlGetString(Daten.project.getProjectName());
             String clubName = EfaUtil.escapeHtmlGetString(Daten.project.getClubName());
-	    out.write("username=" + username +  
-                      "&password=" + password +
-                      (projectId != null ? "&project=" + projectId.toString() : "") +
-                      (projectName != null && projectName.length() > 0 ? "&projectname=" + projectName : "") +
-                      (clubName != null && clubName.length() > 0 ? "&clubname=" + clubName : "") 
-                    );
+            String loginText="username=" + username +  
+                    "&password=" + password +
+                    (projectId != null ? "&project=" + projectId.toString() : "") +
+                    (projectName != null && projectName.length() > 0 ? "&projectname=" + projectName : "") +
+                    (clubName != null && clubName.length() > 0 ? "&clubname=" + clubName : "");
+            out.write(loginText);
             out.flush();
             out.close();
 
@@ -306,8 +533,7 @@ public class KanuEfbSyncTask extends ProgressTask {
 
     private boolean syncUsers() {
         try {
-            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Synchronisiere Personen ...");
-
+           /* logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Synchronisiere Personen ...");
             // ask eFB to sync all users from eFB -> efa
             // this is deprecated
             StringBuilder request = new StringBuilder();
@@ -319,7 +545,7 @@ public class KanuEfbSyncTask extends ProgressTask {
                 return false;
             }
             
-
+*/
             // transmit all efa users without eFB ID's to eFB
             /*
             StringBuilder request = new StringBuilder();
@@ -359,147 +585,7 @@ public class KanuEfbSyncTask extends ProgressTask {
         }
         return true;
     }
-
-    private boolean syncBoats() {
-        try {
-            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Synchronisiere Boote ...");
-            StringBuilder request = new StringBuilder();
-            buildRequestHeader(request, "SyncBoats");
-            Boats boats = Daten.project.getBoats(false);
-            DataKeyIterator it = boats.data().getStaticIterator();
-            DataKey k = it.getFirst();
-            int reqCnt = 0;
-            Hashtable<String,UUID> efaIds = new Hashtable<String,UUID>();
-            while (k != null) {
-                BoatRecord r = (BoatRecord)boats.data().get(k);
-                if (r != null && r.isValidAt(thisSync) && Daten.efaConfig.isCanoeBoatType(r) &&
-                    (r.getLastModified() > lastSync || r.getEfbId() == null || r.getEfbId().length() == 0)) {
-                    if (Logger.isTraceOn(Logger.TT_SYNC)) {
-                        logInfo(Logger.DEBUG, Logger.MSG_SYNC_SYNCINFO, "  erstelle Synchronisierungs-Anfrage für Boot: " + r.getQualifiedName());
-                    }
-                    request.append("<boat><name>"+r.getQualifiedName()+"</name></boat>\n");
-                    efaIds.put(r.getQualifiedName(), r.getId());
-                    reqCnt++;
-                }
-                k = it.getNext();
-            }
-            buildRequestFooter(request);
-
-            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Sende Synchronisierungs-Anfrage für " + reqCnt + " Boote ...");
-            KanuEfbXmlResponse response = sendRequest(request.toString(), true);
-            if (response != null && response.isResponseOk("SyncBoats")) {
-                logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Synchronisierungs-Antwort erhalten für " + response.getNumberOfRecords() + " Boote ...");
-                for (int i=0; i<response.getNumberOfRecords(); i++) {
-                    Hashtable<String,String> fields = response.getFields(i);
-                    boolean ok = false;
-                    String boatName = fields.get("label");
-                    String efbId = fields.get("id");
-                    if (boatName != null) {
-                        boatName = boatName.trim();
-                        UUID efaId = efaIds.get(boatName);
-                        if (efaId != null && efbId != null) {
-                            BoatRecord b = boats.getBoat(efaId, thisSync);
-                            efbId = efbId.trim();
-                            if (b != null) {
-                                if (!efbId.equals(b.getEfbId())) {
-                                    b.setEfbId(efbId);
-                                    boats.data().update(b);
-                                    countSyncBoats++;
-                                }
-                                ok = true;
-                            }
-                        }
-                    }
-                    if (ok) {
-                        if (Logger.isTraceOn(Logger.TT_SYNC)) {
-                            logInfo(Logger.DEBUG, Logger.MSG_SYNC_SYNCINFO, "  Synchronisierungs-Antwort für Boot: "+boatName+" (EfbId="+efbId+")");
-                        }
-                    } else {
-                        logInfo(Logger.WARNING, Logger.MSG_SYNC_WARNINCORRECTRESPONSE, "Ungültige Synchronisierungs-Antwort für Boot: "+boatName);
-                    }
-                }
-                logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, countSyncBoats + " neue Boote synchronisiert.");
-            } else {
-                logInfo(Logger.ERROR, Logger.MSG_SYNC_ERRORINVALIDRESPONSE, "Ungültige Synchronisierungs-Antwort.");
-                return false;
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            return false;
-        }
-        return true;
-    }
-
-    private boolean syncWaters() {
-        try {
-            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Synchronisiere Gewässer ...");
-            StringBuilder request = new StringBuilder();
-            buildRequestHeader(request, "SyncWaters");
-            Waters waters = Daten.project.getWaters(false);
-            DataKeyIterator it = waters.data().getStaticIterator();
-            DataKey k = it.getFirst();
-            int reqCnt = 0;
-            Hashtable<String,UUID> efaIds = new Hashtable<String,UUID>();
-            while (k != null) {
-                WatersRecord r = (WatersRecord)waters.data().get(k);
-                if (r != null && r.isValidAt(thisSync) &&
-                    (r.getLastModified() > lastSync || r.getEfbId() == null || r.getEfbId().length() == 0)) {
-                    if (Logger.isTraceOn(Logger.TT_SYNC)) {
-                        logInfo(Logger.DEBUG, Logger.MSG_SYNC_SYNCINFO, "  erstelle Synchronisierungs-Anfrage für Gewässer: " + r.getQualifiedName());
-                    }
-                    request.append("<water><name>"+r.getQualifiedName()+"</name></water>\n");
-                    efaIds.put(r.getQualifiedName(), r.getId());
-                    reqCnt++;
-                }
-                k = it.getNext();
-            }
-            buildRequestFooter(request);
-
-            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Sende Synchronisierungs-Anfrage für " + reqCnt + " Gewässer ...");
-            KanuEfbXmlResponse response = sendRequest(request.toString(), true);
-            if (response != null && response.isResponseOk("SyncWaters")) {
-                logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Synchronisierungs-Antwort erhalten für " + response.getNumberOfRecords() + " Gewässer ...");
-                for (int i=0; i<response.getNumberOfRecords(); i++) {
-                    Hashtable<String,String> fields = response.getFields(i);
-                    boolean ok = false;
-                    String watersName = fields.get("label");
-                    String efbId = fields.get("id");
-                    if (watersName != null) {
-                        watersName = watersName.trim();
-                        UUID efaId = efaIds.get(watersName);
-                        if (efaId != null && efbId != null) {
-                            WatersRecord w = waters.getWaters(efaId);
-                            efbId = efbId.trim();
-                            if (w != null) {
-                                if (!efbId.equals(w.getEfbId())) {
-                                    w.setEfbId(efbId);
-                                    waters.data().update(w);
-                                    countSyncWaters++;
-                                }
-                                ok = true;
-                            }
-                        }
-                    }
-                    if (ok) {
-                        if (Logger.isTraceOn(Logger.TT_SYNC)) {
-                            logInfo(Logger.DEBUG, Logger.MSG_SYNC_SYNCINFO, "  Synchronisierungs-Antwort für Gewässer: "+watersName+" (EfbId="+efbId+")");
-                        }
-                    } else {
-                        logInfo(Logger.WARNING, Logger.MSG_SYNC_WARNINCORRECTRESPONSE, "Ungültige Synchronisierungs-Antwort für Gewässer: "+watersName);
-                    }
-                }
-                logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, countSyncWaters + " neue Gewässer synchronisiert.");
-            } else {
-                logInfo(Logger.ERROR, Logger.MSG_SYNC_ERRORINVALIDRESPONSE, "Ungültige Synchronisierungs-Antwort.");
-                return false;
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            return false;
-        }
-        return true;
-    }
-
+ 
     private int countNumberOfPersonsWithEfbIds() {
         int count = 0;
         try {
@@ -517,141 +603,110 @@ public class KanuEfbSyncTask extends ProgressTask {
         }
         return count;
     }
-
+        
     private boolean syncTrips() {
         try {
-            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Synchronisiere Fahrten für " +
-                    countNumberOfPersonsWithEfbIds() + " Personen mit Efb-ID's ...");
+        	       	
+        	logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Synchronisiere Fahrten...");
+        	logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Bootstypen, für die Fahrten synchronisiert werden können: "+ Daten.efaConfig.getCanoeBoatTypes());
+            if (Daten.efaConfig.getValueKanuEfb_FullSync() ) {
+            	logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Modus FullSync: Es wird das vollständige Fahrtenbuch übertragen.");           	
+            } else {
+            	logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Modus DifferentialSync: Es werden nur neue und geänderte Fahrten übertragen.");           	
+            }
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Es werden Fahrten ignoriert, deren Beginndatum früher ist als: "+ Daten.efaConfig.getValueKanuEfb_SyncTripsAfterDate().toString());
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Personen mit eFB-IDs, für die Fahrten synchronisiert werden: "+countNumberOfPersonsWithEfbIds());
+            
+            Hashtable<String,LogbookRecord> efaEntryIds = new Hashtable<String,LogbookRecord>();
+
+            boolean isRowingOrCanoeingSession =false;
+            boolean isAlreadySyncedTrip=false;
+            boolean isUnfinishedTrip=false;
+            boolean isTooEarlyTrip=false;
+            boolean isUpdatedTrip=false;
+            boolean isNonSupportedCanoeBoatType=false;
+            boolean isEmptyBoatRecordTrip=false;
+
+            KanuEfbStatistics kStatistics=new KanuEfbStatistics(logbook.data().getNumberOfRecords());
+            
             StringBuilder request = new StringBuilder();
             buildRequestHeader(request, "SyncTrips");
 
-            Boats boats = Daten.project.getBoats(false);
-            Persons persons = Daten.project.getPersons(false);
-            Destinations destinations = Daten.project.getDestinations(false);
-            Waters waters = Daten.project.getWaters(false);
-
             DataKeyIterator it = logbook.data().getStaticIterator();
             DataKey k = it.getFirst();
-            int reqCnt = 0;
-            Hashtable<String,LogbookRecord> efaEntryIds = new Hashtable<String,LogbookRecord>();
+            
             while (k != null) {
                 LogbookRecord r = (LogbookRecord)logbook.data().get(k);
-                if (r != null &&
-                    (r.getLastModified() > r.getSyncTime() || r.getSyncTime() <= 0) &&
-                     r.isRowingOrCanoeingSession() && 
-                     Daten.efaConfig.isCanoeBoatType(r.getBoatRecord(r.getValidAtTimestamp())) ) {
-                    for (int i=0; i<=LogbookRecord.CREW_MAX; i++) {
-                        UUID pId = r.getCrewId(i);
-                        if (pId != null) {
-                            PersonRecord p = persons.getPerson(pId, thisSync);
-                            if (p != null && p.getEfbId() != null && p.getEfbId().length() > 0 &&
-                                r.getDate() != null) {
-                                if (Logger.isTraceOn(Logger.TT_SYNC)) {
-                                    logInfo(Logger.DEBUG, Logger.MSG_SYNC_SYNCINFO, "  erstelle Synchronisierungs-Anfrage für Fahrt: " + r.getQualifiedName()+
-                                            "; Person: "+p.getQualifiedName());
-                                }
-                                BoatRecord b = (r.getBoatId() != null ? boats.getBoat(r.getBoatId(), thisSync) : null);
-                                DestinationRecord d = (r.getDestinationId() != null ? destinations.getDestination(r.getDestinationId(), thisSync): null);
-                                String startDate = r.getDate().getDateString("YYYY-MM-DD");
-                                String endDate = (r.getEndDate() != null ? r.getEndDate().getDateString("YYYY-MM-DD") : startDate);
-                                String tripId = logbook.getName()+"_"+r.getEntryId().toString();
-                                request.append("<trip>");
-                                request.append("<tripID>" + tripId + "</tripID>");
-                                request.append("<userID>" + p.getEfbId() + "</userID>");
-                                if (b != null && b.getEfbId() != null && b.getEfbId().length() > 0) {
-                                    request.append("<boatID>" + b.getEfbId() + "</boatID>");
-                                } else {
-                                    request.append("<boatText><![CDATA[" + (b != null ? b.getQualifiedName() : r.getBoatName()) + "]]></boatText>");
-                                }
-                                request.append("<begdate>" + startDate + "</begdate>");
-                                request.append("<enddate>" + endDate + "</enddate>");
-                                if (r.getStartTime() != null) {
-                                    request.append("<begtime>" + r.getStartTime().toString() + "</begtime>");
-                                }
-                                if (r.getEndTime() != null) {
-                                    request.append("<endtime>" + r.getEndTime().toString() + "</endtime>");
-                                }
-                                
-                                SessionGroupRecord sg = r.getSessionGroup();
-                                String triptype = r.getSessionType();
-                                if (triptype == null || triptype.length() == 0) {
-                                    triptype = EfaTypes.TYPE_SESSION_NORMAL;
-                                }
-                                request.append("<triptype>" + triptype + "</triptype>");
-                                if (sg != null) {
-                                    request.append("<tripgroup>");
-                                    request.append("<name><![CDATA[" + sg.getName() + "]]></name>");
-                                    if (sg.getOrganizer() != null && sg.getOrganizer().length() > 0) {
-                                        request.append("<organizer><![CDATA[" + sg.getOrganizer() + "]]></organizer>");
-                                    }
-                                    request.append("</tripgroup>");
-                                }
+                
+                // Determine session state
+                if (r!= null) {
+                	isAlreadySyncedTrip=false;
+                	// we can only sync trips which took place on a boat, not on a ergometer or a motor boat.
+                	isRowingOrCanoeingSession=r.isRowingOrCanoeingSession();
+                	
+                    // only brand new or updated record shall be sent to EFB.
+                    // we cannot compare r.getLastModified to r.getSyncTime() as r.LastModified gets updated when the SyncTime attribute is set.
+                    // so we compare against lastsync instead, which contains the timestamp AFTER the last successful synchronization.                
+                	if (Daten.efaConfig.getValueKanuEfb_FullSync()) {
+                		isAlreadySyncedTrip=false;
+                		isUpdatedTrip=false;
+                	} else {
+                		isAlreadySyncedTrip=!(r.getLastModified() > lastSync || r.getSyncTime() <= 0);
+                		// Trip has already been synced, but changed after so it gets updated.
+                    	isUpdatedTrip = r.getSyncTime()>0 && r.getLastModified() > lastSync;
+                	}
 
-                                // build waters
-                                ArrayList<String> waterText = new ArrayList<String>();
-                                ArrayList<String> waterID = new ArrayList<String>();
-                                DataTypeList<UUID> waterList = (d != null ? d.getWatersIdList() : null);
-                                DataTypeList<UUID> waterListMore = r.getWatersIdList();
-                                if (waterListMore != null) {
-                                    if (waterList == null) {
-                                        waterList = new DataTypeList<UUID>();
-                                    }
-                                    waterList.addAll(waterListMore);
-                                }
-                                for (int di=0; waterList != null && di<waterList.length(); di++) {
-                                    WatersRecord w = waters.getWaters(waterList.get(di));
-                                    if (w != null) {
-                                        if (w.getEfbId() != null && w.getEfbId().length() > 0) {
-                                            waterID.add(w.getEfbId());
-                                        } else {
-                                            waterText.add(w.getName());
-                                        }
-                                    }
-                                }
-                                DataTypeList<String> waterListText = r.getWatersNameList();
-                                for (int di=0; waterListText != null && di<waterListText.length(); di++) {
-                                    waterText.add(waterListText.get(di));
-                                }
-                                String wIDs = (waterID.size() > 0 ?
-                                    EfaUtil.arr2KommaList(waterID.toArray(new String[0])) : null);
-                                String wTxt = (wIDs == null && waterText.size() > 0 ?
-                                    EfaUtil.arr2KommaList(waterText.toArray(new String[0])) : null);
+                	// EFB denies synchronization for trips which have a start time, but no end time. So we need to detect those.
+                	isUnfinishedTrip = (r.getStartTime()!= null && r.getEndTime()==null);
+                	
+                   	/*
+                	 * Feature: 
+                	 * If a club begins to activate synchronisation of efa trips to efb, some or all of the club members will already have
+                	 * active EFB accounts (so: a kanu_efbID for a person record). These active EFB accounts may already contain trips.
+                	 * 
+                	 * The first time efa tries to sync to efb, it finds all trips in the current logbook need to be synced.
+                	 * And so, for the club members who already have an EFB account with trips, there may be duplicate records created due to
+                	 * the activated sync.  
+                	 * 
+                	 * This may not be a desired scenario. So a new configuration parameter has been established defining the 
+                	 * date a trip has to be started on so that it gets synchronized to efb.
+                	 */
+                	isTooEarlyTrip = r.getDate().isBefore(Daten.efaConfig.getValueKanuEfb_SyncTripsAfterDate());
+                	
+                	isEmptyBoatRecordTrip = r.getBoatRecord(r.getValidAtTimestamp()) == null;
+                	
+                	// We only support EFB synchronization for special boat types, which are set in efaConfig 
+                	isNonSupportedCanoeBoatType = !isCanoeBoatType(r.getBoatRecord(r.getValidAtTimestamp())) && !isEmptyBoatRecordTrip;
+                	
+                	// let's get some statistics...
+                	kStatistics.incrementNonCanoeingTripCntIfTrue(!isRowingOrCanoeingSession);
+                	kStatistics.incrementAlreadySyncedTripCntIfTrue(isAlreadySyncedTrip);                	
+                	if (!isAlreadySyncedTrip) {
 
-                                request.append("<lines>");
-                                request.append("<line>");
-                                if (wIDs != null) {
-                                    request.append("<waterID>" +wIDs + "</waterID>");
-                                } else if (wTxt != null) {
-                                    request.append("<waterText><![CDATA[" + wTxt + "]]></waterText>");
-                                }
-                                if (d != null && d.getStart() != null && d.getStart().length() > 0) {
-                                    request.append("<fromText><![CDATA[" + d.getStart() + "]]></fromText>");
-                                }
-                                if (d != null && d.getEnd() != null && d.getEnd().length() > 0) {
-                                    request.append("<toText><![CDATA[" + d.getEnd() + "]]></toText>");
-                                } else {
-                                    if (r.getDestinationId() != null || r.getDestinationName() != null) {
-                                        request.append("<toText><![CDATA["+ (r.getDestinationId() != null ? r.getDestinationAndVariantName() : r.getDestinationName()) + "]]></toText>");
-                                    }
-                                }
-                                request.append("<kilometers>" + (r.getDistance() != null ? r.getDistance().getStringValueInKilometers() : "0") + "</kilometers>");
-                                request.append("</line>");
-                                request.append("</lines>");
+                		kStatistics.incrementUnfinishedTripCntIfTrue(isUnfinishedTrip);
 
-                                if (r.getComments() != null && r.getComments().length() > 0) {
-                                    request.append("<comment><![CDATA[" + r.getComments() + "]]></comment>");
-                                }
+                		if (!isUnfinishedTrip) {
 
-                                request.append("<changeDate>" + r.getLastModified() + "</changeDate>");
-                                request.append("<status>" + "1" + "</status>");
-                                request.append("<deleted>" + "0" + "</deleted>");
-                                request.append("</trip>\n");
-                                efaEntryIds.put(tripId, r);
-                                reqCnt++;
-                                
-                            }
-                        }
-                    }
+                			kStatistics.incrementTooEarlyTripCntIfTrue(isTooEarlyTrip);
+
+                			if (!isTooEarlyTrip) {
+                				//only one of these values can be true
+                				kStatistics.incrementNonSupportedBoatTypeTriCntIfTrue(isNonSupportedCanoeBoatType);
+                				kStatistics.incrementEmptyBoatRecordTripCntIfTrue(isEmptyBoatRecordTrip);
+                				
+                				if (isEmptyBoatRecordTrip && verboseMode) {
+                                    logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "  Fahrt " +  r.getQualifiedName()+ " - Bootstyp nicht gesetzt/Boot unbekannt: " + r.getBoatAsName());
+                				}
+                			}
+                		}
+                	}
+                }
+                
+                
+                if (r != null && (!isAlreadySyncedTrip) && isRowingOrCanoeingSession && !isNonSupportedCanoeBoatType && !isUnfinishedTrip && !isTooEarlyTrip && !isEmptyBoatRecordTrip) {
+                	
+                	createRequestWithStatistics(request, r, efaEntryIds, kStatistics, isUpdatedTrip);
+                	
                 } else {
                     if (r != null) {
                         if (Logger.isTraceOn(Logger.TT_SYNC)) {
@@ -661,55 +716,251 @@ public class KanuEfbSyncTask extends ProgressTask {
                 }
                 k = it.getNext();
             }
+            
             buildRequestFooter(request);
 
-            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Sende Synchronisierungs-Anfrage für " + reqCnt + " Fahrten ...");
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "-----------");
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Fahrten in DB: "+kStatistics.getTotalTripCnt());
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Fahrten zu synchronisieren (neu): "+kStatistics.getSyncTripCnt());
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Fahrten zu synchronisieren (aktualisiert): "+kStatistics.getUpdatedTripCnt());
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Fahrten zu ignorieren (bereits synchronisiert): "+kStatistics.getAlreadySyncedTripCnt());
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Fahrten zu ignorieren (älter als Startdatum EFB-Sync in Konfig): "+kStatistics.getTooEarlyTripCnt());
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Fahrten zu ignorieren (nicht beendet): "+kStatistics.getUnfinishedTripCnt());
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Fahrten zu ignorieren (Motorboot/Ergo): "+kStatistics.getNonCanoeingTripCnt());
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Fahrten zu ignorieren (kein unterstützter Bootstyp): "+kStatistics.getNonSupportedBoatTypeTripCnt());
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Fahrten zu ignorieren (leerer Bootstyp (unbekanntes Boot?)): "+kStatistics.getEmptyBoatRecordTripCnt()); 
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Fahrten zu ignorieren (keines der Crew-Mitglieder hat Kanu-EFB-ID): "+kStatistics.getPersonWithoutEFBIDTripCnt());
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "-----------");
+            
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Sende Synchronisierungs-Anfrage für " + kStatistics.getRequestCnt() + " Datensätze.");
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Hinweis: Bei mehrsitzigen Booten wird ein Datensatz je Crewmitglied synchronisiert.");
+            
             KanuEfbXmlResponse response = sendRequest(request.toString(), true);
-            if (response != null && response.isResponseOk("SyncTrips")) {
-                logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Synchronisierungs-Antwort erhalten für " + response.getNumberOfRecords() + " Fahrten ...");
-                for (int i=0; i<response.getNumberOfRecords(); i++) {
-                    Hashtable<String,String> fields = response.getFields(i);
-                    boolean ok = false;
-                    String tripId = fields.get("tripid");
-                    int result = EfaUtil.string2int(fields.get("result"), -1);
-                    LogbookRecord r = null;
-                    if (tripId != null) {
-                        tripId = tripId.trim();
-                        r = efaEntryIds.get(tripId);
-                    }
-                    String resultText = fields.get("resulttext");
-                    if (r != null) {
-                        if (result == 0 || // 0 - ok - new trip accepted
-                            result == 1 || // 1 - ok - existing trip updated
-                            result == 2) { // 2 - ok - existing trip deleted
-                            r.setSyncTime(thisSync);
-                            logbook.data().update(r);
-                            ok = true;
-                        }
-                    } else {
-                        logInfo(Logger.WARNING, Logger.MSG_SYNC_WARNINCORRECTRESPONSE, "Fehler beim Synchronisieren von Fahrt: Trip ID "+tripId+" unbekannt (Code "+result+" - "+resultText+")");
-                    }
-                    if (ok) {
-                        countSyncTrips++;
-                        if (Logger.isTraceOn(Logger.TT_SYNC)) {
-                            logInfo(Logger.DEBUG, Logger.MSG_SYNC_SYNCINFO, "  Fahrt erfolgreich synchronisiert: "+r.toString());
-                        }
-                    } else {
-                        logInfo(Logger.WARNING, Logger.MSG_SYNC_WARNINCORRECTRESPONSE, "Fehler beim Synchronisieren von Fahrt: "+tripId+" (Code "+result+" - "+resultText+")");
-                    }
-                }
-                logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, countSyncTrips + " Fahrten synchronisiert.");
-            } else {
-                logInfo(Logger.ERROR, Logger.MSG_SYNC_ERRORINVALIDRESPONSE, "Ungültige Synchronisierungs-Antwort.");
-                return false;
-            }
+            
+            return handleSyncTripsResponse (response, efaEntryIds, kStatistics);
+
         } catch (Exception e) {
             e.printStackTrace();
             return false;
         }
-        return true;
+
     }
 
+    private boolean handleSyncTripsResponse(KanuEfbXmlResponse response, Hashtable<String,LogbookRecord> efaEntryIds, KanuEfbStatistics statistics) {
+    	
+    	try {
+	        if (response != null && response.isResponseOk("SyncTrips")) {
+	            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Synchronisierungs-Antwort erhalten für " + response.getNumberOfRecords() + " Datensätze ...");
+	            for (int i=0; i<response.getNumberOfRecords(); i++) {
+	                Hashtable<String,String> fields = response.getFields(i);
+	                boolean ok = false;
+	                String tripId = fields.get("tripid");
+	                int result = EfaUtil.string2int(fields.get("result"), -1);
+	                LogbookRecord r = null;
+	                if (tripId != null) {
+	                    tripId = tripId.trim();
+	                    r = efaEntryIds.get(tripId);
+	                }
+	                String resultText = fields.get("resulttext");
+	                if (r != null) {
+	                    if (result == 0 || // 0 - ok - new trip accepted
+	                        result == 1 || // 1 - ok - existing trip updated
+	                        result == 2) { // 2 - ok - existing trip deleted
+	                        r.setSyncTime(thisSync);
+	                        logbook.data().update(r);
+	                        ok = true;
+	                    }
+	                } else {
+	                    logInfo(Logger.WARNING, Logger.MSG_SYNC_WARNINCORRECTRESPONSE, "Fehler beim Synchronisieren von Fahrt: Trip ID "+tripId+" unbekannt (Code "+result+" - "+resultText+")");
+	                }
+	                if (ok) {
+	                    countSyncTrips++;
+	                    if (Logger.isTraceOn(Logger.TT_SYNC)) {
+	                        logInfo(Logger.DEBUG, Logger.MSG_SYNC_SYNCINFO, "  Fahrt erfolgreich synchronisiert: "+r.toString());
+	                    }
+	                } else {
+	                    logInfo(Logger.WARNING, Logger.MSG_SYNC_WARNINCORRECTRESPONSE, "Fehler beim Synchronisieren von Fahrt: "+tripId+" (Code "+result+" - "+resultText+")");
+	                }
+	            }
+	            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, countSyncTrips + "/"+ statistics.getRequestCnt() +  " Datensätze synchronisiert.");
+	        } else {
+	            logInfo(Logger.ERROR, Logger.MSG_SYNC_ERRORINVALIDRESPONSE, "Ungültige Synchronisierungs-Antwort.");
+	            logInfo(Logger.ERROR, Logger.MSG_SYNC_ERRORINVALIDRESPONSE, "Auf EFB-Schulungssystemen kann ggfs. die Konfigurationsoption 'XML-Antworten auf EFB-Schulungssystemen bereinigen' weiterhelfen.");
+	            return false;
+	        }    	
+	        //wenn alles geklappt hat - ok zurückgeben
+	        return true;
+    	 } catch (Exception e) {
+             e.printStackTrace();
+             return false;
+         }
+    }
+    
+    private void createRequestWithStatistics(StringBuilder request,  LogbookRecord r, Hashtable<String,LogbookRecord> efaEntryIds, KanuEfbStatistics statistics, boolean isUpdatedTrip) {
+    	//we want to check if the current trip leads to at least one request. 
+    	//if not, the trip is ignored due to the fact that none of the crew members has an EfbID.
+    	long oldRequestCnt=statistics.getRequestCnt(); 
+    	boolean isTripWithAtLeastOneCrewMemberWithEFBID=false;
+    	boolean isTripWithIdentifiedCrewMember=false;
+    	String unidentifiedCrewMembers="";
+    	
+        Boats boats = Daten.project.getBoats(false);
+        Persons persons = Daten.project.getPersons(false);
+        Destinations destinations = Daten.project.getDestinations(false);
+        Waters waters = Daten.project.getWaters(false);
+    	
+    	
+    	//Steuermann zuzüglich bis zu 24 Crewmitglieder auf eine EFB-ID prüfen.
+    	for (int i=0; i<=LogbookRecord.CREW_MAX; i++) {
+            UUID pId = r.getCrewId(i);
+
+            if (pId != null) {
+            	isTripWithIdentifiedCrewMember=true;
+            	PersonRecord p = persons.getPerson(pId, thisSync);
+                if (p != null && p.getEfbId() != null && p.getEfbId().length() > 0 &&
+                    r.getDate() != null) {
+                    if (Logger.isTraceOn(Logger.TT_SYNC)) {
+                        logInfo(Logger.DEBUG, Logger.MSG_SYNC_SYNCINFO, "  erstelle Synchronisierungs-Anfrage für Fahrt: " + r.getQualifiedName()+
+                                "; Person: "+p.getQualifiedName());
+                    }
+                    
+                    isTripWithAtLeastOneCrewMemberWithEFBID=true;
+                    
+                    BoatRecord b = (r.getBoatId() != null ? boats.getBoat(r.getBoatId(), thisSync) : null);
+                    DestinationRecord d = (r.getDestinationId() != null ? destinations.getDestination(r.getDestinationId(), thisSync): null);
+                    String startDate = r.getDate().getDateString("YYYY-MM-DD");
+                    String endDate = (r.getEndDate() != null ? r.getEndDate().getDateString("YYYY-MM-DD") : startDate);
+                    String tripId = logbook.getName()+"_"+r.getEntryId().toString();
+                    request.append("<trip>");
+                    request.append("<tripID>" + tripId + "</tripID>");
+                    request.append("<userID>" + p.getEfbId() + "</userID>");
+                    if (b != null && b.getEfbId() != null && b.getEfbId().length() > 0) {
+                        request.append("<boatID>" + b.getEfbId() + "</boatID>");
+                    } else {
+                        request.append("<boatText><![CDATA[" + (b != null ? b.getQualifiedName() : r.getBoatName()) + "]]></boatText>");
+                    }
+                    request.append("<begdate>" + startDate + "</begdate>");
+                    request.append("<enddate>" + endDate + "</enddate>");
+                    if (r.getStartTime() != null) {
+                        request.append("<begtime>" + r.getStartTime().toString() + "</begtime>");
+                    }
+                    if (r.getEndTime() != null) {
+                        request.append("<endtime>" + r.getEndTime().toString() + "</endtime>");
+                    }
+                    
+                    SessionGroupRecord sg = r.getSessionGroup();
+                    String triptype = r.getSessionType();
+                    if (triptype == null || triptype.length() == 0) {
+                        triptype = EfaTypes.TYPE_SESSION_NORMAL;
+                    }
+                    request.append("<triptype>" + triptype + "</triptype>");
+                    if (sg != null) {
+                        request.append("<tripgroup>");
+                        request.append("<name><![CDATA[" + sg.getName() + "]]></name>");
+                        if (sg.getOrganizer() != null && sg.getOrganizer().length() > 0) {
+                            request.append("<organizer><![CDATA[" + sg.getOrganizer() + "]]></organizer>");
+                        }
+                        request.append("</tripgroup>");
+                    }
+
+                    // build waters
+                    ArrayList<String> waterText = new ArrayList<String>();
+                    ArrayList<String> waterID = new ArrayList<String>();
+                    DataTypeList<UUID> waterList = (d != null ? d.getWatersIdList() : null);
+                    DataTypeList<UUID> waterListMore = r.getWatersIdList();
+                    if (waterListMore != null) {
+                        if (waterList == null) {
+                            waterList = new DataTypeList<UUID>();
+                        }
+                        waterList.addAll(waterListMore);
+                    }
+                    for (int di=0; waterList != null && di<waterList.length(); di++) {
+                        WatersRecord w = waters.getWaters(waterList.get(di));
+                        if (w != null) {
+                            if (w.getEfbId() != null && w.getEfbId().length() > 0) {
+                                waterID.add(w.getEfbId());
+                            } else {
+                                waterText.add(w.getName());
+                            }
+                        }
+                    }
+                    DataTypeList<String> waterListText = r.getWatersNameList();
+                    for (int di=0; waterListText != null && di<waterListText.length(); di++) {
+                        waterText.add(waterListText.get(di));
+                    }
+                    String wIDs = (waterID.size() > 0 ?
+                        EfaUtil.arr2KommaList(waterID.toArray(new String[0])) : null);
+                    String wTxt = (wIDs == null && waterText.size() > 0 ?
+                        EfaUtil.arr2KommaList(waterText.toArray(new String[0])) : null);
+
+                    request.append("<lines>");
+                    request.append("<line>");
+                    if (wIDs != null) {
+                        request.append("<waterID>" +wIDs + "</waterID>");
+                    } else if (wTxt != null) {
+                        request.append("<waterText><![CDATA[" + wTxt + "]]></waterText>");
+                    }
+                    if (d != null && d.getStart() != null && d.getStart().length() > 0) {
+                        request.append("<fromText><![CDATA[" + d.getStart() + "]]></fromText>");
+                    }
+                    if (d != null && d.getEnd() != null && d.getEnd().length() > 0) {
+                        request.append("<toText><![CDATA[" + d.getEnd() + "]]></toText>");
+                    } else {
+                        if (r.getDestinationId() != null || r.getDestinationName() != null) {
+                            request.append("<toText><![CDATA["+ (r.getDestinationId() != null ? r.getDestinationAndVariantName() : r.getDestinationName()) + "]]></toText>");
+                        }
+                    }
+                    request.append("<kilometers>" + (r.getDistance() != null ? r.getDistance().getStringValueInKilometers() : "0") + "</kilometers>");
+                    request.append("</line>");
+                    request.append("</lines>");
+
+                    if (r.getComments() != null && r.getComments().length() > 0) {
+                        request.append("<comment><![CDATA[" + r.getComments() + "]]></comment>");
+                    }
+
+                    request.append("<changeDate>" + r.getLastModified() + "</changeDate>");
+                    request.append("<status>" + "1" + "</status>");
+                    request.append("<deleted>" + "0" + "</deleted>");
+                    request.append("</trip>\n");
+                    efaEntryIds.put(tripId, r);
+                    statistics.incrementRequestCnt();
+                    
+                }
+            }
+            else if (pId==null) {
+            	unidentifiedCrewMembers = (unidentifiedCrewMembers+ " "+ r.getCrewAsName(i)).trim();
+            }
+        } // end of for each Crew Member
+    	
+    	
+      	// if the number of requests has not changed, none of the crew members has an EFB ID, so the trip is ignored...
+    	statistics.incrementPersonWithoutEFBIDTripCntIfTrue(oldRequestCnt==statistics.getRequestCnt());
+       	//personWithoutEFBIDTripCnt = (oldRequestCnt==requestCnt) ? personWithoutEFBIDTripCnt+1 : personWithoutEFBIDTripCnt;
+    	
+       	statistics.incrementUpdatedtripCntIfTrue(isTripWithAtLeastOneCrewMemberWithEFBID && isUpdatedTrip);
+       	statistics.incrementSyncTripCntIfTrue(isTripWithAtLeastOneCrewMemberWithEFBID && !isUpdatedTrip);
+//    	if (isTripWithAtLeastOneCrewMemberWithEFBID && isUpdatedTrip) {
+//    		updatedTripCnt++;
+//        } else if (isTripWithAtLeastOneCrewMemberWithEFBID && !isUpdatedTrip) {
+//        	syncTripCnt++;
+//        } else 
+       	if (!isTripWithIdentifiedCrewMember && verboseMode){
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "  Fahrt " +  r.getQualifiedName()+ " - Keines der Crewmitglieder in der Personenliste: "+ unidentifiedCrewMembers);
+        }
+    }
+    
+    public boolean isCanoeBoatType(BoatRecord r) {
+        Object[] types = Daten.efaConfig.getValueKanuEfb_CanoeBoatTypes();
+        for (int i=0; r != null && i<r.getNumberOfVariants(); i++) {
+            for (int j=0; types != null && j<types.length; j++) {
+                if (types[j] != null && types[j].toString().equals(r.getTypeType(i))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }    
+    
     private boolean syncDone() {
         try {
             if (loggedIn) {
@@ -751,25 +1002,24 @@ public class KanuEfbSyncTask extends ProgressTask {
                 break;
             }
             setCurrentWorkDone(++i);
-            if (!syncBoats()) {
-                break;
-            }
-            setCurrentWorkDone(++i);
-            if (!syncWaters()) {
-                break;
-            }
-            setCurrentWorkDone(++i);
             if (!syncTrips()) {
                 break;
             }
             setCurrentWorkDone(++i);
+            
             break;
         }
         syncDone();
         setCurrentWorkDone(++i);
+        
         if (i == getAbsoluteWork()) {
-            Daten.project.setClubKanuEfbLastSync(thisSync);
-            StringBuilder msg = new StringBuilder();
+        
+        	// We need to store the timestamp AFTER the last successful synchronization to "lastSync"
+        	// so that we can compare the record's lastModified timestamp against it in syncTrips().
+        	
+        	Daten.project.setClubKanuEfbLastSync(System.currentTimeMillis());
+            
+        	StringBuilder msg = new StringBuilder();
             if (countErrors == 0) {
                 if (countWarnings == 0) {
                     msg.append("Synchronisierung mit Kanu-eFB erfolgreich beendet.");
@@ -779,10 +1029,9 @@ public class KanuEfbSyncTask extends ProgressTask {
             } else {
                 msg.append("Synchronisierung mit Kanu-eFB mit Fehlern beendet.");
             }
+            logInfo(Logger.INFO, Logger.MSG_SYNC_SYNCINFO, "Endzeit der Synchronisierung: " +  EfaUtil.getTimeStamp(thisSync) + " (" + thisSync + ")");
             msg.append(" [");
             msg.append(countSyncUsers  + " Personen, ");
-            msg.append(countSyncBoats  + " Boote, ");
-            msg.append(countSyncWaters + " Gewässer, ");
             msg.append(countSyncTrips  + " Fahrten synchronisiert] [");
             msg.append(countWarnings   + " Warnungen, ");
             msg.append(countErrors     + " Fehler");
@@ -797,7 +1046,7 @@ public class KanuEfbSyncTask extends ProgressTask {
     }
 
     public int getAbsoluteWork() {
-        return 6;
+        return 4; //login, sync persons, sync trips, logout.
     }
 
     public String getSuccessfullyDoneMessage() {
@@ -805,8 +1054,6 @@ public class KanuEfbSyncTask extends ProgressTask {
             return LogString.operationSuccessfullyCompleted(International.getString("Synchronisation")) +
                    "\n"   + countSyncTrips + " Fahrten synchronisiert." +
                    "\n"   + countSyncUsers + " Personen synchronisiert." +
-                   "\n"   + countSyncBoats + " Boote synchronisiert." +
-                   "\n"   + countSyncWaters + " Gewässer synchronisiert." +
                    "\n\n" + countWarnings + " Warnungen" +
                    "\n"   + countErrors + " Fehler";
         } else {
@@ -885,5 +1132,13 @@ public class KanuEfbSyncTask extends ProgressTask {
     public boolean isSuccessfullyCompleted() {
         return successfulCompleted;
     }
+
+	public boolean getVerboseMode() {
+		return verboseMode;
+	}
+
+	public void setVerboseMode(boolean verboseMode) {
+		this.verboseMode = verboseMode;
+	}
 
 }

--- a/de/nmichael/efa/gui/util/EfaMenuButton.java
+++ b/de/nmichael/efa/gui/util/EfaMenuButton.java
@@ -951,7 +951,7 @@ public class EfaMenuButton {
                 insufficientRights(admin, action);
                 return false;
             }
-            KanuEfbSyncTask syncTask = new KanuEfbSyncTask(logbook, admin);
+            KanuEfbSyncTask syncTask = new KanuEfbSyncTask(logbook, admin, true);//always verbose mode when running sync in GUI
             ProgressDialog progressDialog = (parentFrame != null ?
                     new ProgressDialog(parentFrame, International.onlyFor("Mit Kanu-eFB synchronisieren", "de"), syncTask, false) :
                     new ProgressDialog(parentDialog, International.onlyFor("Mit Kanu-eFB synchronisieren", "de"), syncTask, false) );


### PR DESCRIPTION
Zusammenfassung
---------
- Kanu-eFB Synchronisation
	- komplett überarbeitet
	- Konfiguration über Konfig->Synchronisation (Expertenmodus)
		- Auswahl zwischen vollständigem Sync oder nur Sync der neuen und geänderteten Fahrten (DIFF)
		- Auswahl des Datums, ab dem die Fahrten synchronisiert werden sollen (nur interessant für Vereine, die die EFB-Sync das erste Mal einsetzen)
		- Support für Macken des EFB-Schulungssystems
	- die zu synchronisiertenden Bootstypen können nun gespeichert werden

	- Intensive Protokollierung, welche Fahrten synchronisiert bzw. nicht synchronisiert werden
		- dadurch auch mengenmäßig nachvollziehbar, wie viele der Fahrten aus welchem Grund nicht synchronisiert werden
		- Unterschied zwischen Anzahl Fahrten im EFA und übermittelter Datensätze nachvollziehbar
		- leider ist das Protokoll da sehr geschwätzig, wenn es viele unbekannte Boote oder Gast-Fahrer gibt - Verbose Mode Protokollierung - in Synchronisation via GUI Standard - muss in efaCLI-Synchronisation explizit angefordert werden mit -verbose option

	- Was EFA->EFB Sync macht und welche Eigenheiten es hat, siehe Foreneintrag http://forum.nmichael.de/viewtopic.php?f=9&t=1351
		- wobei diese Eigenheiten unabhängig von der Überarbeitung in dieser Version ist!

MenuBase.java
---------
removeOptionsFromArgs()
- new functions to get rid of all options (-optionname=value) from the args, returning parameters like filename

MenuSyncEfb.java
---------
printHelpContext()
- added verbose mode

syncEfb()
- verbose mode off by default - can be enabled b applying option in parameters
- refactored getting logBookName from parameters due to verbose mode option

EfaConfig.java
---------
new options for kanuEfb_SyncTripsAfterDate, kanuEfb_Fullsync, kanuEfb_TidyXML
    - these options have no international support as they are useful for german clubs only

updateValue()
- fixed bug so that not yet safed options get safed in efaConfigRecord.
  - neccessary to fix safing kanEfb_boatTypes

buildTypes()
- refactored option kanuEfb_BoatTypes - get CanoeBoatTypes if empty - get safed CanoeBoatTypes from kanuEfb_BoatTypes in efaConfig

getCanoeBoatTypes()
- refactored option kanuEfb_BoatTypes
- if a list of actual canoe boat types is set as parameter, return those
   - else use the standard list of canoe boat types

class ConfigValueUpdateThread.updateConfigValuesWithPersistance()
- fixed bug with infinite loop

KanuEfbStatistics.Java
---------
class for detailed statistics during synchonisation

KanuEfbSyncTask.java
---------
Complete refactoring of Sync task.
See summary. See extensive documentation within the file.

Tested since 8/2022 in Canoe club KSC Hannover.