### PR TITLE
Filter for texts in autocomplete lists

### DIFF
--- a/de/nmichael/efa/core/config/EfaConfig.java
+++ b/de/nmichael/efa/core/config/EfaConfig.java
@@ -132,6 +132,7 @@ public class EfaConfig extends StorageObject implements IItemFactory {
     private ItemTypeBoolean postfixPersonsWithClubName;
     private ItemTypeBoolean allowSessionsWithoutDistance;
     private ItemTypeBoolean popupComplete;
+    private ItemTypeBoolean popupContainsMode;
     private ItemTypeStringList nameFormat;
     private ItemTypeBoolean correctMisspelledNames;
     private ItemTypeBoolean skipUhrzeit;
@@ -609,6 +610,9 @@ public class EfaConfig extends StorageObject implements IItemFactory {
             addParameter(popupComplete = new ItemTypeBoolean("AutoCompleteListShow", true,
                     IItemType.TYPE_EXPERT,BaseTabbedDialog.makeCategory(CATEGORY_COMMON, CATEGORY_GUI),
                     International.getString("Beim Vervollständigen Popup-Liste anzeigen")));
+            addParameter(popupContainsMode= new ItemTypeBoolean("AutoCompleteContainsMode", true,
+            		IItemType.TYPE_EXPERT,BaseTabbedDialog.makeCategory(CATEGORY_COMMON, CATEGORY_GUI),
+            		International.getString("Popup-Liste nach Teilbegriff durchsuchen (statt nach Wortanfang)")));               
             addParameter(fensterZentriert = new ItemTypeBoolean("WindowCentered", false,
                     IItemType.TYPE_EXPERT,BaseTabbedDialog.makeCategory(CATEGORY_COMMON, CATEGORY_GUI),
                     International.getString("Alle Fenster in Bildschirmmitte zentrieren")));
@@ -1449,7 +1453,11 @@ public class EfaConfig extends StorageObject implements IItemFactory {
     public boolean getValuePopupComplete() {
         return popupComplete.getValue();
     }
-
+    
+    public boolean getValuePopupContainsMode() {
+    	return popupContainsMode.getValue();
+    }
+    
     public String getValueNameFormat() {
         return nameFormat.getValue();
     }

--- a/de/nmichael/efa/gui/SimpleInputDialog.java
+++ b/de/nmichael/efa/gui/SimpleInputDialog.java
@@ -52,7 +52,9 @@ public class SimpleInputDialog extends BaseDialog {
     }
 
     protected void iniDialog() throws Exception {
-        KEYACTION_ENTER = addKeyAction("ENTER");
+   		//better than addKeyAction("ENTER") as the default button is handled earlier
+    	//and provides better user experience
+    	this.getRootPane().setDefaultButton(closeButton);
 
         // create GUI items
         mainPanel.setLayout(new GridBagLayout());

--- a/de/nmichael/efa/gui/SimpleOptionInputDialog.java
+++ b/de/nmichael/efa/gui/SimpleOptionInputDialog.java
@@ -87,6 +87,12 @@ public class SimpleOptionInputDialog extends SimpleInputDialog implements IItemL
             });
             buttonPanel.add(button);
             buttonActions.put(button, optionButtonAction[i]);
+            
+            // choose the last button in the list with OPTION_OK as default button 
+            if (optionButtonAction[i]==OPTION_OK) {
+            	this.getRootPane().setDefaultButton(button);
+            }
+            
             if (optionButtonIcons != null && optionButtonIcons.length > i &&
                 optionButtonIcons[i] != null) {
                 button.setIcon(getIcon(optionButtonIcons[i]));

--- a/de/nmichael/efa/gui/dataedit/BoatDamageListDialog.java
+++ b/de/nmichael/efa/gui/dataedit/BoatDamageListDialog.java
@@ -76,7 +76,7 @@ public class BoatDamageListDialog extends DataListDialog {
         if (record == null) {
             long now = System.currentTimeMillis();
             ItemTypeStringAutoComplete boat = new ItemTypeStringAutoComplete("BOAT", "", IItemType.TYPE_PUBLIC,
-                    "", International.getString("Boot"), false);
+                    "", International.getString("Boot"), true);//true=use autocomplete list
             boat.setAutoCompleteData(new AutoCompleteList(Daten.project.getBoats(false).data(), now, now));
             if (SimpleInputDialog.showInputDialog(this, International.getString("Boot auswählen"), boat)) {
                 String s = boat.toString();

--- a/de/nmichael/efa/gui/util/AutoCompletePopupWindow.java
+++ b/de/nmichael/efa/gui/util/AutoCompletePopupWindow.java
@@ -114,7 +114,7 @@ public class AutoCompletePopupWindow extends JWindow {
             autoCompleteLists.put(list, data);
             autoCompleteSCN.put(list, new Long(list.getSCN()));
         }
-        this.list.setListData(data);
+        this.list.setListData(list.getData());
         return data.length;
     }
 
@@ -168,6 +168,15 @@ public class AutoCompletePopupWindow extends JWindow {
         }
     }
 
+    /*
+     * Returns the currently selected entry in the popup window.
+     * Needed for filtered autocomplete lists.
+     */
+
+    public  String getSelectedEintrag() {
+    	return (String)list.getSelectedValue();
+    }
+    
     private void listEntrySelected(MouseEvent e) {
         if (showingAt != null) {
             try {

--- a/efa_de.properties
+++ b/efa_de.properties
@@ -1224,6 +1224,7 @@ Plugin_{plugin}_ist_bereits_installiert.=Plugin {1} ist bereits installiert.
 Plugins=Plugins
 Poloboot=Poloboot
 Popup=Popup
+Popup-Liste_nach_Teilbegriff_durchsuchen_(statt_nach_Wortanfang)=Popup-Liste nach Teilbegriff durchsuchen (statt nach Wortanfang)
 Position=Position
 Postleitzahl=Postleitzahl
 Postleitzahl_und_Ort=Postleitzahl und Ort

--- a/efa_en.properties
+++ b/efa_en.properties
@@ -1224,6 +1224,7 @@ Plugin_{plugin}_ist_bereits_installiert.=Plugin {1} is already installed.
 Plugins=Plugins
 Poloboot=Polo Boat
 Popup=Popup
+Popup-Liste_nach_Teilbegriff_durchsuchen_(statt_nach_Wortanfang)=Popups search for full text search instead of searching for prefix
 Position=Position
 Postleitzahl=Zip Code
 Postleitzahl_und_Ort=Zip Code and City


### PR DESCRIPTION
Summary
---------
- Autocomplete lists support filtering in contains mode. 
- So when you enter a text within a textfield which supports autocomplete, a list is opened with those entries which contain the text. 
- Also, the behaviour of the keys UP, DOWN, ENTER is changed when filtering in contains mode, so that the user can use these keys to choose between several values in the filtered list. 
- compatible with aliases for persons

- When leaving a field with autocomplete by hitting TAB, the list for similar entries in the list is shown. - when option to filter in contains mode is on, entries which contain the former value are added to the list of similar entries.

- Default on, can be disabled via Config->common->Appearance in expert mode

- Known glitch: sometimes the autocomplete popup does not show up automatically. Have not been able to determine why.
  - Editing Boats -> Usage -> Default crew
  - Editing Boats -> Usage -> Specifying groups which can use the boat

- Should be compatible with fix for lists loosing persons after late entry of trips (https://github.com/nicmichael/efa/commit/522929d85a12ee98a864ffaf551e79be8ea080a4)
  - did a short test, which worked fine.

EfaConfig.Java
---------
Added a new parameter AutoCompleteContainsmode, default enabled, as TYPE_EXPERT

efa_de.properties, efa_en.properties
---------
Added international support for new property

ItemTypeStringAutoComplete.java
---------
Added some documentation for the class and its user handling in the diffrent autocomplete modes.

iniDisplay()
- added new keylistener for handling ENTER key. Works effectevely only when SimpleInputDialog and SImpleOptionInputDialog use a default button instead of VK_ENTER handling - as swing event handling makes it difficult having multiple keylisteners for the same key (VK_ENTER)

autoComplete()
- new filtered list handling added (by calling a diffrent function which handles new filtered lists)

checkSpelling()
- if filtered lists are enabled, also entries matching the given value in contains mode are added to the list.

handeFilteredList()
- handles the list in contains mode. Diffrent behaviour concerning UP, DOWN, ENTER, DELETE Keys

SimpleInputDialog.java
---------
- uses java defaultbutton instad of VK_ENTER handling

SimpleOptionInputDialog.java
---------
- uses java defaultbutton instad of VK_ENTER handling

AutoCompleteList.java
---------
Added some documentation for the class and its user handling in the diffrent autocomplete modes. Including the new dataVisibleFiltered list.

Added attributes for dataVisibleFiltered list and filter text.

setFilterText()
- sets filtertext trimmed and lowercase

updateVisibleFilterList()
- filters list dataVisible for filtertext
- compatible with alias names for persons

update()
- calls updateVisibleFilteredList

getNext() / getNext(prefix)
- always works on dataVisibleFilteredlist, as dataVisibleFilteredList equals dataVisible if not filtered

getPrev() / getPrev(prefix)
- always works on dataVisibleFilteredlist, as dataVisibleFilteredList equals dataVisible if not filtered

getLast()
- always works on dataVisibleFilteredlist, as dataVisibleFilteredList equals dataVisible if not filtered

getData()
- always works on dataVisibleFilteredlist, as dataVisibleFilteredList equals dataVisible if not filtered

reset()
- set dataVisible, sorts it (may be unneccessary, but who knows) and applies filter if neccessary.

AutoCompletePopupWindows.java
---------
setListData()
- adapted, so it can handle filtered lists

getSelectedEintrag()
- wrapper for protected list.getSelectedValue()

BoatDamageListDialog
---------
createNewDataEditDialog()
- use autocomplete list for boat field