### PR TITLE
MN EFA048 filterfield todays boatreservations

### DIFF
--- a/de/nmichael/efa/core/items/ItemTypeDataRecordTable.java
+++ b/de/nmichael/efa/core/items/ItemTypeDataRecordTable.java
@@ -571,7 +571,7 @@ public class ItemTypeDataRecordTable extends ItemTypeTable implements IItemListe
         tablePanel.repaint();
     }
 
-    protected void updateData() {
+    public void updateData() {
         if (persistence == null) {
             return;
         }
@@ -723,5 +723,13 @@ public class ItemTypeDataRecordTable extends ItemTypeTable implements IItemListe
     	filterBySearch.setValue(value);
     	updateFilter();
     	updateData();
+    }
+    
+    public ItemTypeString getSearchField(){
+    	return searchField;
+    };
+    
+    public ItemTypeBoolean getFilterBySearch() {
+    	return filterBySearch;
     }
 }

--- a/de/nmichael/efa/gui/dataedit/BoatReservationListDialog.java
+++ b/de/nmichael/efa/gui/dataedit/BoatReservationListDialog.java
@@ -15,6 +15,7 @@ import de.nmichael.efa.core.config.AdminRecord;
 import de.nmichael.efa.core.items.*;
 import de.nmichael.efa.data.*;
 import de.nmichael.efa.data.storage.*;
+import de.nmichael.efa.data.types.DataTypeDate;
 import de.nmichael.efa.gui.SimpleInputDialog;
 import de.nmichael.efa.gui.util.AutoCompleteList;
 import de.nmichael.efa.util.*;
@@ -29,6 +30,7 @@ import javax.swing.*;
 public class BoatReservationListDialog extends DataListDialog {
 
     boolean allowNewReservationsWeekly = true;
+	protected ItemTypeBoolean showTodaysReservationsOnly;
 
     public BoatReservationListDialog(Frame parent, AdminRecord admin) {
         super(parent, International.getString("Bootsreservierungen"), Daten.project.getBoatReservations(false), 0, admin);
@@ -101,6 +103,9 @@ public class BoatReservationListDialog extends DataListDialog {
             actionType = new int[] { };
         }
         this.allowNewReservationsWeekly = allowNewReservationsWeekly;
+        
+		//From and to columns should be wider than default
+		this.minColumnWidths = new int[] {150,120,120,120,12};   
     }
 
 
@@ -179,4 +184,47 @@ public class BoatReservationListDialog extends DataListDialog {
 		//show only matching items by default in BoatDamageListDialog 
 		table.setIsFilterSet(true);
 	}
+	
+    protected void iniControlPanel() {
+    	// we want to put an additional element after the control panel
+    	super.iniControlPanel();
+    	this.iniBoatReservationListFilter();
+    }
+	
+	private void iniBoatReservationListFilter() {
+		JPanel myControlPanel= new JPanel();
+    	
+		showTodaysReservationsOnly = new ItemTypeBoolean("SHOW_TODAYS_RESERVATIONS_ONLY",
+                false,
+                IItemType.TYPE_PUBLIC, "", International.getString("nur heutige Reservierungen anzeigen"));
+		showTodaysReservationsOnly.setPadding(0, 0, 0, 0);
+		showTodaysReservationsOnly.displayOnGui(this, myControlPanel, 0, 0);
+		showTodaysReservationsOnly.registerItemListener(this);
+        mainPanel.add(myControlPanel, BorderLayout.NORTH);
+	}
+	
+    public void itemListenerAction(IItemType itemType, AWTEvent event) {
+    	
+    	// handle our special filter for today's reservations, else use default item handler
+    	if (itemType.equals(showTodaysReservationsOnly)) {
+    		
+    		 if (event.getID() == ActionEvent.ACTION_PERFORMED) {
+    			 showTodaysReservationsOnly.getValueFromGui();
+    			 if (showTodaysReservationsOnly.getValue()) {
+    				 table.getSearchField().setValue(DataTypeDate.today().toString());
+    				 table.getFilterBySearch().setValue(true);
+    				 table.updateData();
+    				 table.showValue();
+    			 } else {
+    				 table.getSearchField().setValue("");
+    				 table.getFilterBySearch().setValue(true);
+    				 table.updateData();
+    				 table.showValue();
+    			 }
+    		 }
+    		
+    	} else {
+    		super.itemListenerAction(itemType, event);
+    	}
+    }	
 }

--- a/efa_de.properties
+++ b/efa_de.properties
@@ -1170,6 +1170,7 @@ Nur_f\u00fcr_das_Boot_maximal_m\u00f6gliche_Anzahl_an_Personen_erlauben=Nur f\u0
 nur_f\u00fcr_{something}=nur f\u00fcr {1}
 nur_Gruppe=nur Gruppe
 nur_Gutschriften=nur Gutschriften
+nur_heutige_Reservierungen_anzeigen=Nur heutige Reservierungen anzeigen
 nur_offene_Bootssch\u00e4den=nur offene Bootssch\u00e4den
 nur_Person=nur Person
 Nutzer=Nutzer

--- a/efa_en.properties
+++ b/efa_en.properties
@@ -1170,6 +1170,7 @@ Nur_f\u00fcr_das_Boot_maximal_m\u00f6gliche_Anzahl_an_Personen_erlauben=Only all
 nur_f\u00fcr_{something}=only for {1}
 nur_Gruppe=only Group
 nur_Gutschriften=nur Gutschriften
+nur_heutige_Reservierungen_anzeigen=Show today's reservations only
 nur_offene_Bootssch\u00e4den=only open boat damages
 nur_Person=only Person
 Nutzer=User

--- a/efa_fr.properties
+++ b/efa_fr.properties
@@ -1773,3 +1773,4 @@ efa_kann_in_dem_ge\u00E4nderten_Verzeichnis_f\u00FCr_Nutzerdaten_nicht_schreiben
 Schriftstil=Style de la police
 maximale_Dialog-H\u00F6he=hauteur maximale du dialogue
 email__{subject}__wird_im_Hintergrund_versendet_...=Le courriel ''{1}'' sera envoy\u00E9 en arri\u00E8re plan ...
+nur_heutige_Reservierungen_anzeigen=r\u00E9servations du jour

--- a/eou/eou.xml
+++ b/eou/eou.xml
@@ -9,16 +9,18 @@
         <Changes lang="de">
             <ChangeItem>Neu: efa 2.3.3 erfordert mindestens Java Version 8</ChangeItem>
             <ChangeItem>Neu: Bootsreservierungen (sowohl einmalige als auch wöchentliche) lassen sich jetzt nach Datum filtern</ChangeItem>
+            <ChangeItem>Neu: Bootsreservierungen lassen sich per Checkbox auf den heutigen Tag filtern</ChangeItem>
             <ChangeItem>Bugfix: efaCloud Überschreiben von Fahrten in efaCloud bei Fahrtenbuchwechsel</ChangeItem>
             <ChangeItem>Bugfix: efaCloud Synchronisationsabweichungstoleranz zu eng</ChangeItem>
             <ChangeItem>Neu: efaCloud Eigenes Logging für Synchronisationsfehler</ChangeItem>
         </Changes>
         <Changes lang="en">
             <ChangeItem>New: efa 2.3.3. requires at least Java Vesion 8</ChangeItem>
-            <ChangeItem>Neu: Boat reservations (both one-time and weekly reservations) can now be filtered by date</ChangeItem>
+            <ChangeItem>New: Boat reservations (both one-time and weekly reservations) can now be filtered by date</ChangeItem>
+            <ChangeItem>New: Boat reservations can be filtered for today's reservations only (new checkbox)</ChangeItem>            
             <ChangeItem>Bugfix: efaCloud overwriting of sessions when switching logbook</ChangeItem>
             <ChangeItem>Bugfix: efaCloud too little tolerance for data synchronization</ChangeItem>
-            <ChangeItem>Neu: efaCloud logging of synchronization errors</ChangeItem>
+            <ChangeItem>New: efaCloud logging of synchronization errors</ChangeItem>
         </Changes>
     </Version>
 


### PR DESCRIPTION
Summary
------------
Boat reservation dialog now has a filter checkbox on top so that the reservations shown are limited to entries applying today.

This is achievedby simply replacing the search field's contents by today's date.

So we are re-using a not-so-obvious function of EFA_0017_FILTER_BOATRESERVATIONS_BY_DATE_REPLAY

ItemTypeDataRecordTable.java
------
- set updateData() function to PUBLIC
- added getters for searchField and the checkbox filterBySearch

BoatReservationListDialog.java
------
- set minimum column widths a bit wider for "from" and "to" columns.

iniControlPanel.java
------
- iniControlPanel() added to provide the additional filter

- iniBoatReservationListFilter() new method, adds a new panel above the record table

- itemListenerAction() new method, adds GUI logic to handle checking/unchecking the new filter checkbox

Language property files
------
Added language support for nur_heutige_Reservierungen_anzeigen