### PR TITLE
MN EFA 053 Plugin xml update

### DIFF
--- a/de/nmichael/efa/files/plugins.xml
+++ b/de/nmichael/efa/files/plugins.xml
@@ -36,12 +36,12 @@
 
     <Plugin name="mail">
         <FullName>JavaMail</FullName>
-        <Version>1.5.1</Version>
+        <Version>1.6.2</Version>
         <Copyright>Copyright (c) Oracle America, licensed under the Oracle Binary Code License Agreement for Java EE Technologies</Copyright>
         <Description lang="de">email-Versand in efa</Description>
         <Description lang="en">Sending of emails from efa</Description>
         <Files baseurl="http://efa.nmichael.de/plugins/mail/">
-            <File size="545362">javax.mail.jar</File>
+            <File size="659033">javax.mail.jar</File>
             <File size="56290">activation.jar</File>
         </Files>
     </Plugin>

--- a/eou/eou.xml
+++ b/eou/eou.xml
@@ -12,13 +12,15 @@
             <ChangeItem>Bugfix: efaCloud Überschreiben von Fahrten in efaCloud bei Fahrtenbuchwechsel</ChangeItem>
             <ChangeItem>Bugfix: efaCloud Synchronisationsabweichungstoleranz zu eng</ChangeItem>
             <ChangeItem>Neu: efaCloud Eigenes Logging für Synchronisationsfehler</ChangeItem>
+            <ChangeItem>Bugfix: plugin.xml verweist auf korrekte JavaMail-Version 1.6.2</ChangeItem>
         </Changes>
         <Changes lang="en">
             <ChangeItem>New: efa 2.3.3. requires at least Java Vesion 8</ChangeItem>
-            <ChangeItem>Neu: Boat reservations (both one-time and weekly reservations) can now be filtered by date</ChangeItem>
+            <ChangeItem>New: Boat reservations (both one-time and weekly reservations) can now be filtered by date</ChangeItem>
             <ChangeItem>Bugfix: efaCloud overwriting of sessions when switching logbook</ChangeItem>
             <ChangeItem>Bugfix: efaCloud too little tolerance for data synchronization</ChangeItem>
-            <ChangeItem>Neu: efaCloud logging of synchronization errors</ChangeItem>
+            <ChangeItem>New: efaCloud logging of synchronization errors</ChangeItem>
+            <ChangeItem>Bugfix: plugin.xml now correctly reports current version 1.6.2 of JavaMail</ChangeItem>
         </Changes>
     </Version>
 


### PR DESCRIPTION
plugin.xml now correctly references version 1.6.2 of javamail library.