### PR TITLE
When using efa sporadically at home, records are sometimes not updated,…

### DIFF
--- a/de/nmichael/efa/data/efacloud/SynchControl.java
+++ b/de/nmichael/efa/data/efacloud/SynchControl.java
@@ -42,6 +42,12 @@ class SynchControl {
     boolean synch_upload = false;
     boolean synch_upload_all = false;
     boolean synch_download_all = false;
+    // efaCloudRolleBths is true if the efacloud user role is that of a boathouse. If true, this will enforce
+    // pre-modification checks during download synchronization
+    boolean efaCloudRolleBths = true;
+    // isBoathouseApp is true, if this s run as efaBoathouse. This will enforce pre-modification checks during download
+    // synchronization
+    boolean isBoathouseApp = true;
 
     int table_fixing_index = -1;
     ArrayList<String> tables_to_synchronize = new ArrayList<String>();
@@ -480,7 +486,8 @@ class SynchControl {
     /**
      * Compares two records whether it is probable that one is the update of the other. If three or more data fields
      * differ, it is not believed that one is an update of the other and a data update conflict is created instead of
-     * updating.
+     * updating. Exception is made, if neither the role of the efaCloudUser is "bths" nor the application mode efaBths,
+     * to ensure proper download synchronisation when using efa at home sporadically.
      *
      * @param dr1 DataRecord one to compare
      * @param dr2 DataRecord two to compare
@@ -488,6 +495,8 @@ class SynchControl {
      * @return empty String, if the records are of the same type and differ in only a tolerable amount of data fields
      */
     private String preUpdateRecordsCompare(DataRecord dr1, DataRecord dr2, String tablename) {
+        if (!efaCloudRolleBths && !isBoathouseApp)
+            return "";
         if ((dr1 == null) || (dr2 == null) || (dr1.getClass() != dr2.getClass()))
             return "type mismatch";
         // if archiving is executed or an archived record is restored, do not check for mismatches

--- a/de/nmichael/efa/data/efacloud/TxResponseHandler.java
+++ b/de/nmichael/efa/data/efacloud/TxResponseHandler.java
@@ -243,9 +243,11 @@ public class TxResponseHandler {
                     for (String param : cfg) {
                         if (param.contains("=")) {
                             String name = param.split("=", 2)[0];
-                            if (name.equalsIgnoreCase("server_welcome_message"))
+                            if (name.equalsIgnoreCase("server_welcome_message")) {
                                 txq.serverWelcomeMessage = param.split("=", 2)[1].replace("//", "\n");
-                            else if (name.equalsIgnoreCase("db_layout"))
+                                txq.synchControl.efaCloudRolleBths = txq.serverWelcomeMessage.contains("Rolle: bths");
+                                txq.synchControl.isBoathouseApp = (Daten.applID == Daten.APPL_EFABH);
+                            } else if (name.equalsIgnoreCase("db_layout"))
                                 Daten.tableBuilder.mapServerDBLayout(param.split("=", 2)[1]);
                             else {
                                 int val = -1;


### PR DESCRIPTION
… because they differ in too many fields. This update-Check is needed to protect boathouse data from erroneous updates in hazard situations. Now a check is made on the situation, so that in cases in which efa is used as efaBase and the efacloudUser-role is not boat house the preupdate checks are skipped.