### PR TITLE
Updated Look of AdminDialog, VersionizedDataEditDialog

### DIFF
--- a/de/nmichael/efa/core/items/ItemTypeButton.java
+++ b/de/nmichael/efa/core/items/ItemTypeButton.java
@@ -24,7 +24,8 @@ public class ItemTypeButton extends ItemType {
     protected JButton button;
     protected ImageIcon icon;
     protected Insets margin;
-
+    protected boolean boldfont;
+    
     public ItemTypeButton(String name, 
             int type, String category, String description) {
         this.name = name;
@@ -40,6 +41,7 @@ public class ItemTypeButton extends ItemType {
     	if (margin!=null) {
     		newItem.setMargin(margin.top,margin.left, margin.bottom, margin.right);
 	    }
+    	newItem.setBold(this.boldfont);
     	return newItem;
     }
 
@@ -76,6 +78,9 @@ public class ItemTypeButton extends ItemType {
             public void focusGained(FocusEvent e) { field_focusGained(e); }
             public void focusLost(FocusEvent e) { field_focusLost(e); }
         });
+        if(boldfont) {
+        	button.setFont(button.getFont().deriveFont(Font.BOLD));
+        }
         button.setVisible(isVisible);
         this.field = button;
         saveBackgroundColor(true);
@@ -152,4 +157,9 @@ public class ItemTypeButton extends ItemType {
     		button.setMargin(this.margin);     
     	}
     }
+    
+    public void setBold(Boolean value) {
+    	this.boldfont=value;
+    }
 }
+

--- a/de/nmichael/efa/gui/AdminDialog.java
+++ b/de/nmichael/efa/gui/AdminDialog.java
@@ -68,6 +68,7 @@ public class AdminDialog extends BaseDialog implements IItemListener {
         String lastMenuName = null;
         int y = 0;
         int space = 0;
+        String spaceForMenuName="";
         for (EfaMenuButton menuButton : menuButtons) {
             if (!menuButton.getMenuName().equals(lastMenuName)) {
                 // New Menu
@@ -93,9 +94,15 @@ public class AdminDialog extends BaseDialog implements IItemListener {
                 if (panel == null) {
                     continue;
                 }
-                JLabel label = new JLabel();
+                JLabel label = new RoundedLabel();
                 Mnemonics.setLabel(this, label, menuButton.getMenuText());
                 label.setHorizontalAlignment(SwingConstants.CENTER);
+                label.setBackground(Daten.efaConfig.getHeaderBackgroundColor());
+                label.setForeground(Daten.efaConfig.getHeaderForegroundColor());
+                label.setOpaque(true);
+                label.setFont(label.getFont().deriveFont(Font.BOLD));
+                label.setBorder(new RoundedBorder(label.getForeground()));
+                
                 y = 0;
                 panel.add(label,
                         new GridBagConstraints(0, y++, 1, 1, 0.0, 0.0,
@@ -108,6 +115,10 @@ public class AdminDialog extends BaseDialog implements IItemListener {
             }
             if (menuButton.getButtonName().equals(EfaMenuButton.SEPARATOR)) {
                 space = 10;
+                //memorize for which menu the spacer is intended.
+                //because the whole menu is within a list, and it could be that 
+                //a menu ends with a spacer (due to lacking competences of the current admin).
+                spaceForMenuName=menuButton.getMenuName();
             } else {
                 ItemTypeButton button = new ItemTypeButton(menuButton.getButtonName(),
                         IItemType.TYPE_PUBLIC, menuButton.getMenuName(), menuButton.getButtonText());
@@ -120,10 +131,13 @@ public class AdminDialog extends BaseDialog implements IItemListener {
                 button.setFieldSize(200, 20);
                 button.setHorizontalAlignment(SwingConstants.LEFT);
                 button.registerItemListener(this);
-                if (space > 0) {
-                    button.setPadding(0, 0, space, 0);
+                button.setBold(true);
+            	//put some space above a button only if the spacer belongs
+            	//to the same menu group as the current button.
+                if ((space > 0) && (menuButton.getMenuName().equalsIgnoreCase(spaceForMenuName))){
+                	button.setPadding(0, 0, space, 0);
                 }
-                button.displayOnGui(this, panel, 0, y++);
+	            button.displayOnGui(this, panel, 0, y++);
                 space = 0;
             }
         }
@@ -131,7 +145,7 @@ public class AdminDialog extends BaseDialog implements IItemListener {
         // left side
         centerPanel.add(menuFile,
                 new GridBagConstraints(0, 0, 1, 2, 0.0, 0.0,
-                        GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
+                        GridBagConstraints.NORTH, GridBagConstraints.HORIZONTAL,
                         new Insets(10, 10, 10, 10), 0, 0));
         if (Daten.efaConfig.getDeveloperFunctionsActivated()) {
             centerPanel.add(menuDeveloper,
@@ -141,15 +155,19 @@ public class AdminDialog extends BaseDialog implements IItemListener {
         }
 
         // middle
+        // menuAdministration has a lot of elements, it takes a full column.
+        // if we stick to "CENTER" here, this will also lead to a VERTIAL centation
+        // of the panel. But no, we want all topmost panels to be at the same height
+        // for optical beauty.
         centerPanel.add(menuAdministration,
                 new GridBagConstraints(1, 0, 1, 3, 0.0, 0.0,
-                        GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
+                        GridBagConstraints.NORTH, GridBagConstraints.HORIZONTAL,
                         new Insets(10, 10, 10, 10), 0, 0));
 
         // right
         centerPanel.add(menuConfiguration,
                 new GridBagConstraints(2, 0, 1, 1, 0.0, 0.0,
-                        GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
+                        GridBagConstraints.NORTH, GridBagConstraints.HORIZONTAL,
                         new Insets(10, 10, 10, 10), 0, 0));
         centerPanel.add(menuOutput,
                 new GridBagConstraints(2, 1, 1, 1, 0.0, 0.0,
@@ -174,17 +192,20 @@ public class AdminDialog extends BaseDialog implements IItemListener {
                 new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0,
                         GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
                         new Insets(10, 10, 10, 10), 0, 0));
+        projectName.setFont(projectName.getFont().deriveFont(Font.BOLD));
         logbookName = new JLabel();
         northPanel.add(logbookName,
                 new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0,
                         GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
                         new Insets(10, 10, 10, 10), 0, 0));
+        logbookName.setFont(logbookName.getFont().deriveFont(Font.BOLD));
 
         clubworkName = new JLabel();
         northPanel.add(clubworkName,
                 new GridBagConstraints(2, 0, 1, 1, 0.0, 0.0,
                         GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
                         new Insets(10, 10, 10, 10), 0, 0));
+        clubworkName.setFont(clubworkName.getFont().deriveFont(Font.BOLD));
 
         updateInfos();
         mainPanel.add(northPanel, BorderLayout.NORTH);

--- a/de/nmichael/efa/gui/dataedit/VersionizedDataEditDialog.java
+++ b/de/nmichael/efa/gui/dataedit/VersionizedDataEditDialog.java
@@ -51,10 +51,22 @@ public class VersionizedDataEditDialog extends UnversionizedDataEditDialog imple
         JPanel versionPanel = new JPanel();
         versionPanel.setLayout(new GridBagLayout());
 
+        /* Panel layout
+         * 
+         * |                 |                 |                   |                   |       
+         * |[                       Versionen                     ]|				   |
+         * |[                                                     ]| [Auswählen]	   | 
+         * |[           Table 3 rows high                         ]| [Neu]    		   |
+         * |[ 									                  ]| [Löschen]         |
+         * |[Versionlabel                     ]|[           Gültigkeitszeitraum ändern]|       
+         * 
+         */
+        
         JLabel versionLabel = new JLabel();
         Mnemonics.setLabel(this, versionLabel, International.getString("Versionen"));
-        versionPanel.add(versionLabel, new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0,
-                                    GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(10, 10, 0, 0), 0, 0));
+        versionPanel.add(versionLabel, new GridBagConstraints(0, 0, 2, 1, 0.0, 0.0,
+                                    GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(10, 10, 0, 0), 0, 0));
+        versionLabel.setFont(versionLabel.getFont().deriveFont(Font.BOLD));
 
         //versionList = new ItemTypeHtmlList("VERSION_LIST", null, null, null, IItemType.TYPE_PUBLIC, null, International.getString("Versionen"));
         versionList = new ItemTypeTable("VERSION_LIST", new String[] {
@@ -69,7 +81,7 @@ public class VersionizedDataEditDialog extends UnversionizedDataEditDialog imple
         };
         versionList.setPopupActions(actions);
         versionList.registerItemListener(this);
-        versionList.setFieldGrid(2, 3, GridBagConstraints.CENTER, GridBagConstraints.NONE);
+        versionList.setFieldGrid(2, 3, GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL);
         versionList.setPadding(10, 10, 0, 10);
         versionList.setFieldSize(500, 100);
         versionList.displayOnGui(_parent, versionPanel, 0, 1);
@@ -109,8 +121,9 @@ public class VersionizedDataEditDialog extends UnversionizedDataEditDialog imple
 
         selectedVersionLabel = new JLabel();
         Mnemonics.setLabel(this, selectedVersionLabel, International.getString("Version"));
-        versionPanel.add(selectedVersionLabel, new GridBagConstraints(0, 4, 1, 1, 0.0, 0.0,
+        versionPanel.add(selectedVersionLabel, new GridBagConstraints(0, 4, 2, 1, 0.0, 0.0,
                                     GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(30, 0, 5, 0), 0, 0));
+        selectedVersionLabel.setFont(selectedVersionLabel.getFont().deriveFont(Font.BOLD));
 
         JButton versionValidityChangeButton = new JButton();
         Mnemonics.setButton(this, versionValidityChangeButton, 


### PR DESCRIPTION
Updated Look of AdminDialog, VersionizedDataEditDialog

Versionized Data Edit Dialogs
- table vor versions now scale horizontally with the dialogs' size.

AdminDialog: 
- Ensured all panels "FILE", "ADMINISTRATION", "MANAGEMENT" are at the same height for a clean layout.
- Panels have RoundedLabels as headings.
- All buttons in bold font
- labels for project, logbook, clubwork in bold font

Sample of the updates for the efaBths Admin Dialog:
![grafik](https://github.com/nicmichael/efa/assets/73741388/01614110-9f33-4561-aabb-c0c730b4bcbc)
