### PR TITLE
MN EFA 057 efaConfig + FlatLaf - Bugfix for autocomplete Lists

### DIFF
--- a/de/nmichael/efa/Daten.java
+++ b/de/nmichael/efa/Daten.java
@@ -72,7 +72,7 @@ public class Daten {
 
     public final static String VERSION            = "2.3.4"; // Version für die Ausgabe (z.B. 2.1.0, kann aber auch Zusätze wie "alpha" o.ä. enthalten)
     public final static String VERSIONID          = "2.3.4_#1 Beta ";   // VersionsID: Format: "X.Y.Z_MM"; final-Version z.B. 1.4.0_00; beta-Version z.B. 1.4.0_#1
-    public final static String VERSIONRELEASEDATE = "01.01.2024";  // Release Date: TT.MM.JJJJ
+    public final static String VERSIONRELEASEDATE = "02.01.2024";  // Release Date: TT.MM.JJJJ
     public final static String MAJORVERSION       = "2";
     public final static String PROGRAMMID         = "EFA.233"; // Versions-ID für Wettbewerbsmeldungen
     public final static String PROGRAMMID_DRV     = "EFADRV.233"; // Versions-ID für Wettbewerbsmeldungen

--- a/de/nmichael/efa/gui/util/AutoCompleteList.java
+++ b/de/nmichael/efa/gui/util/AutoCompleteList.java
@@ -91,6 +91,12 @@ public class AutoCompleteList {
     public AutoCompleteList() {
     }
 
+    //for debug purposes
+    public synchronized String getSizes() {
+    	return (dataVisible==null ? "visible: null " : "visible: "+dataVisible.size()) +  
+    			(dataVisibleFiltered==null ? " dataVisibleFiltered: null " : "dataVisibleFiltered: "+dataVisibleFiltered.size());
+    }
+    
     public AutoCompleteList(IDataAccess dataAccess) {
         setDataAccess(dataAccess);
     }

--- a/de/nmichael/efa/gui/util/AutoCompletePopupWindow.java
+++ b/de/nmichael/efa/gui/util/AutoCompletePopupWindow.java
@@ -48,7 +48,11 @@ import java.util.*;
 
 public class AutoCompletePopupWindow extends JWindow {
 
-    private static AutoCompletePopupWindow window = null;
+    /**
+	 * 
+	 */
+	private static final long serialVersionUID = -2544348417400727743L;
+	private static AutoCompletePopupWindow window = null;
     private Hashtable<AutoCompleteList,String[]> autoCompleteLists = new Hashtable<AutoCompleteList,String[]>();
     private Hashtable<AutoCompleteList,Long> autoCompleteSCN = new Hashtable<AutoCompleteList,Long>();
     private JTextField showingAt;
@@ -170,6 +174,9 @@ public class AutoCompletePopupWindow extends JWindow {
             // Unter Windows bewirkt toFront(), daß der ursprüngliche Frame den Fokus verliert, daher muß unter Windows darauf verzichtet werden
             if (!Daten.osName.startsWith("Windows")) {
                 this.toFront();
+            } else { 
+            	//unter windows reicht aber, das fenster wieder sichtbar zu machen, damit es ganz oben angezeigt wird.
+            	this.setVisible(true);
             }
             return;
         }
@@ -195,6 +202,7 @@ public class AutoCompletePopupWindow extends JWindow {
             showingAt = field;
             lastShowingAt = showingAt;
         } catch (Exception ee) { // nur zur Sicherheit: Es gibt seltene Exceptions in efa, die keiner Stelle im Code zugeordnet werden können und hierher kommen könnten
+        	Logger.logdebug(ee);
         }
     }
 

--- a/eou/eou.xml
+++ b/eou/eou.xml
@@ -23,7 +23,7 @@
             <ChangeItem>BugFix: Icons zum Hinzufügen von Elementen sind dunkler und besser wahrnehmbar.</ChangeItem>              
             <ChangeItem>BugFix: Tabellen mit alternierenden Zeilen nutzen die LookAndFeel-Farben als Standardfarbe anstatt fest weisse Hintergrundfarbe zu nutzen.</ChangeItem>
             <ChangeItem>BugFix: Überflüssige grafische Rahmen entfernt in efaBths und allen Dialogen.</ChangeItem>
-            <ChangeItem>BugFix: Autovervollständigen-Felder zeigten sich manchmal nicht an. Zusätzlich: STRG+F öffnet das Autovervollständigen-Feld.</ChangeItem>
+            <ChangeItem>BugFix: Autovervollständigen-Felder zeigten sich unter Windows nicht mehr an, wenn man zwischenzeitlich in einem anderen Programm war. Zusätzlich: STRG+F öffnet das Autovervollständigen-Feld.</ChangeItem>
             <ChangeItem>BugFix: Autovervollständigen-Felder: werden diese mit TAB verlassen, wird der gewählte Eintrag übernommen.</ChangeItem>
             <ChangeItem>BugFix: Fahrt Beginnen Dialog: Taste ESC in Autovervollständigen-Feldern schließt nur die Auswahlbox, nicht den gesamten Dialog.</ChangeItem>
             <ChangeItem>BugFix: Lesen von Nachrichten: im Textfeld kann nun Text mit der Maus markiert und mit STRG+C in die Zwischenablage übernommen werden.</ChangeItem>
@@ -61,7 +61,7 @@
             <ChangeItem>BugFix: Tables with alternating row colors use the lookandfeel specific colors instead of plain white background color.</ChangeItem>
             <ChangeItem>BugFix: Removed unneccesary borders in efaBths and all dialogs.</ChangeItem>
             <ChangeItem>BugFix: Icons for adding new items use a darker green and are better recognizable.</ChangeItem>              
-			<ChangeItem>BugFix: Autocomplete fields sometimes did now show the popup window. Also, STRG+F now opens the popup window.</ChangeItem>
+			<ChangeItem>BugFix: Autocomplete fields did not show their popup window on Windows machines, when user changed to another program and returned to efa. Also, STRG+F now opens the popup window.</ChangeItem>
             <ChangeItem>BugFix: Autocomplete fields: if user leaves a popup selection with tab, the selected entry is used for the field.</ChangeItem>
             <ChangeItem>BugFix: Start session dialog: Hitting ESC while an autocomplete window is open, only the autocomplete window is closed instead of the start session dialog.</ChangeItem>
             <ChangeItem>BugFix: EfaConfig: Scrollable in the config window is INSIDE the tabs - making it easier to scroll</ChangeItem>


### PR DESCRIPTION
Bugfix#1 Changed behaviour of TAB Key in Autcomplete fields
A TAB key (or a focuslost event) on a autocomplete element always took over the actual selected element. If the popup list opened by accident, this lead to unwanted commentment to the selected value.

So, when hitting the TAB key or loosing focus by klicking somewhere else, the selected element is only taken if the user entered at least one character in the text field.

Bugfix#2 AutoComplete field not showing
This happens under windows only. If you open the lookup window on a field, then click into another program and then back into efaBths in the currently open field, the lookup list never showed up on windows. It stayed in the background.

By now when returning into the mask with the open autocomplete window, you just have to hit a key so that the popup window shows again.