### PR TITLE
From tfyh to integrate in efa 2.3.4 beta

### DIFF
--- a/de/nmichael/efa/data/efacloud/TxRequestQueue.java
+++ b/de/nmichael/efa/data/efacloud/TxRequestQueue.java
@@ -11,8 +11,6 @@
 package de.nmichael.efa.data.efacloud;
 
 import de.nmichael.efa.Daten;
-import de.nmichael.efa.core.config.AdminRecord;
-import de.nmichael.efa.core.config.Admins;
 import de.nmichael.efa.gui.EfaBaseFrame;
 import de.nmichael.efa.gui.EfaBoathouseFrame;
 import de.nmichael.efa.gui.EfaCloudConfigDialog;
@@ -697,21 +695,6 @@ public class TxRequestQueue implements TaskManager.RequestDispatcherIF {
     }
 
     /**
-     * Full application restart to reset all queues and communication. The function is provided for the raspberry bootup
-     * system time issue.
-     */
-    void restartEfa() {
-        if (efaGUIroot instanceof EfaBoathouseFrame) {
-            // Indicate the restart cause. This has no effect on the queue handling.
-            Logger.log(Logger.WARNING, Logger.MSG_EFACLOUDSYNCH_INFO, International
-                    .getMessage("Kommunikation zu '{URL}' ist nachhaltig gestört. Versuche einen Neustart des Programms zur Behebung.",
-                            efaCloudUrl));
-            AdminRecord admin = Daten.admins.getAdmin(Admins.SUPERADMIN);
-            ((EfaBoathouseFrame) efaGUIroot).cancel(null, EfaBoathouseFrame.EFA_EXIT_REASON_AUTORESTART, admin, true);
-        }
-    }
-
-    /**
      * Display the current status in the GUI.
      */
     public void showStatusAtGUI() {
@@ -1275,4 +1258,3 @@ public class TxRequestQueue implements TaskManager.RequestDispatcherIF {
     }
 
 }
-

--- a/de/nmichael/efa/data/efacloud/TxResponseHandler.java
+++ b/de/nmichael/efa/data/efacloud/TxResponseHandler.java
@@ -26,7 +26,6 @@ import static de.nmichael.efa.data.efacloud.TxRequestQueue.TX_BUSY_QUEUE_INDEX;
 public class TxResponseHandler {
 
     private final TxRequestQueue txq;
-    private int internetabortionCount = 0;
 
     TxResponseHandler(TxRequestQueue txq) {
         this.txq = txq;
@@ -317,12 +316,6 @@ public class TxResponseHandler {
             // the transaction container sending was aborted.
             TxResponseContainer txrc = new TxResponseContainer(null);
             handleTxcError(txrc, text + ";;" + txcResp.title);
-            internetabortionCount++;
-            // Abortion of a container request shall be very rare. And efa shall restart every day anyways, so this
-            // condition typically is hit when facing the raspberry system time adjustment. Restart efa to handle the
-            // situation.
-            if (internetabortionCount > 100)
-                txq.restartEfa();
 
             // } else if (type == InternetAccessManager.TYPE_PROGRESS_INFO) { // not relevant
             // } else if (type == InternetAccessManager.TYPE_FILE_SIZE_INFO) { // not relevant

--- a/de/nmichael/efa/gui/EfaCloudConfigDialog.java
+++ b/de/nmichael/efa/gui/EfaCloudConfigDialog.java
@@ -32,7 +32,7 @@ import java.util.Vector;
  */
 public class EfaCloudConfigDialog extends BaseTabbedDialog implements IItemListener {
 
-    private static final String ACTIVATION_INFO = "ACTIVATION_INFO";
+	private static final String ACTIVATION_INFO = "ACTIVATION_INFO";
     private static final String BUTTON_EFACLOUD_ACTIVATE = "BUTTON_EFACLOUD_ACTIVATE";
     private static final String BUTTON_EFACLOUD_DEACTIVATE = "BUTTON_EFACLOUD_DEACTIVATE";
     private static final String BUTTON_EFACLOUD_START = "BUTTON_EFACLOUD_START";
@@ -250,11 +250,15 @@ public class EfaCloudConfigDialog extends BaseTabbedDialog implements IItemListe
             // if the current storage type is xml, this method is called to make it efaCloud
             // That will also trigger a rebuild of the server side tables.
             if (pr.getProjectStorageType() == IDataAccess.TYPE_FILE_XML) {
-                if (itemType.getName().equalsIgnoreCase(BUTTON_EFACLOUD_ACTIVATE)) {
+                String efaCloudURL = ((ItemTypeString) super.getItem("efaCloudURL")).getValue();
+                String storageUsername = ((ItemTypeString) super.getItem("efaCloudUsername")).getValue();
+                String storagePassword = ((ItemTypeString) super.getItem("efaCloudPassword")).getValue();
+                if (itemType.getName().equalsIgnoreCase(BUTTON_EFACLOUD_ACTIVATE) && (efaCloudURL.length() > 7)
+                    && (storageUsername.length() > 1) && (storagePassword.length() > 7)) {
                     // read the entered parameters into the project record.
-                    pr.setProjectEfaCloudURL(((ItemTypeString) super.getItem("efaCloudURL")).getValue());
-                    pr.setProjectStorageUsername(((ItemTypeString) super.getItem("efaCloudUsername")).getValue());
-                    pr.setProjectStoragePassword(((ItemTypeString) super.getItem("efaCloudPassword")).getValue());
+                    pr.setProjectEfaCloudURL(efaCloudURL);
+                    pr.setProjectStorageUsername(storageUsername);
+                    pr.setProjectStoragePassword(storagePassword);
                     pr.setProjectStorageType(IDataAccess.TYPE_EFA_CLOUD);
                     // Store the changed settings
                     String prjName = pr.getName();
@@ -299,6 +303,16 @@ public class EfaCloudConfigDialog extends BaseTabbedDialog implements IItemListe
                         return;
                     }
                 }
+                else if (itemType.getName().equalsIgnoreCase(BUTTON_EFACLOUD_ACTIVATE))
+                    if (efaCloudURL.length() <= 7)
+                        de.nmichael.efa.util.Dialog.infoDialog(International.getString("URL zu kurz"),
+                            International.getString("efaCloud wurde nicht aktiviert. Bitte versuche es neu."));
+                    else if (storageUsername.length() <= 1)
+                        de.nmichael.efa.util.Dialog.infoDialog(International.getString("Benutzername zu kurz"),
+                                International.getString("efaCloud wurde nicht aktiviert. Bitte versuche es neu."));
+                    else if (storagePassword.length() <= 7)
+                        de.nmichael.efa.util.Dialog.infoDialog(International.getString("Paßwort zu kurz"),
+                                International.getString("efaCloud wurde nicht aktiviert. Bitte versuche es neu."));
             }
 
             // other efaCloud actions


### PR DESCRIPTION
@tfyh
a) when the upload synchronization fails to read the efaCloud record … 1e763f7

…status it tries to insert all recent records into efaCloud. The efaCloud doublet check will filter out doublets, but may miss those records which wer modified in the meantime. This change reduces the "recent" period from 30 to 5 days and fixes a logic bug when deciding what update to take (full or partial)

b) when at year end people cleanse the data, multiple names may be replaced by UUIDs in logbook records resulting in a lot of changed fields although this is still the very same session. Logbook record update plausibility therefore shall require identity of EntryId, BoatId, Date,
  StartTime and EndTime instead of a maximum number of arbitrary fields changed.

@tfyh
Behebung des gemeldeten Fehlers von Stefan: "Mir ist noch ein Bug auf… be5088a

…gefallen, wenn man efaCloud aktivieren möchte für das Projekt: Klickt man in dem entsprechenden Dialog von Dir ohne das Ausfüllen von den zugehörigen Feldern auf den Knopf zur Umstellung auf efaCloud, dann macht er das trotzdem mit dem Projekt, kann dieses aber zukünftig nicht mehr laden. D.h. man kann das Projekt danach nicht mehr mit efa-Boardmitteln korrigieren, weil es sich grundsätzlich nicht mehr laden lässt."