### PR TITLE
MultiThreading Bugfix für Widgets

### DIFF
--- a/de/nmichael/efa/Daten.java
+++ b/de/nmichael/efa/Daten.java
@@ -70,9 +70,9 @@ import de.nmichael.efa.util.Logger;
 // @i18n complete
 public class Daten {
 
-    public final static String VERSION            = "2.3.4 Beta Flatlaf 2212"; // Version für die Ausgabe (z.B. 2.1.0, kann aber auch Zusätze wie "alpha" o.ä. enthalten)
+    public final static String VERSION            = "2.3.4 Beta Flatlaf 1640"; // Version für die Ausgabe (z.B. 2.1.0, kann aber auch Zusätze wie "alpha" o.ä. enthalten)
     public final static String VERSIONID          = "2.3.4_#3";   // VersionsID: Format: "X.Y.Z_MM"; final-Version z.B. 1.4.0_00; beta-Version z.B. 1.4.0_#1
-    public final static String VERSIONRELEASEDATE = "06.01.2024";  // Release Date: TT.MM.JJJJ
+    public final static String VERSIONRELEASEDATE = "08.01.2024";  // Release Date: TT.MM.JJJJ
     public final static String MAJORVERSION       = "2";
     public final static String PROGRAMMID         = "EFA.233"; // Versions-ID für Wettbewerbsmeldungen
     public final static String PROGRAMMID_DRV     = "EFADRV.233"; // Versions-ID für Wettbewerbsmeldungen

--- a/de/nmichael/efa/gui/EfaBoathouseFrame.java
+++ b/de/nmichael/efa/gui/EfaBoathouseFrame.java
@@ -875,7 +875,7 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
         if (clock == null) {
             clock = new ClockMiniWidget();
         }
-        clock.getGuiComponent().setVisible(Daten.efaConfig.getValueEfaDirekt_showUhr());
+        clock.setVisible(Daten.efaConfig.getValueEfaDirekt_showUhr());
     }
 
     private void updateGuiNews() {
@@ -884,7 +884,7 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
         }
         news.setText(Daten.efaConfig.getValueEfaDirekt_newsText());
         news.setScrollSpeed(Daten.efaConfig.getValueEfaDirekt_newsScrollSpeed());
-        news.getGuiComponent().setVisible(Daten.efaConfig.getValueEfaDirekt_showNews());
+        news.setVisible(Daten.efaConfig.getValueEfaDirekt_showNews());
         if (isDisplayable()) {
             packFrame("updateGuiNews()");
         }

--- a/de/nmichael/efa/gui/widgets/HTMLWidget.java
+++ b/de/nmichael/efa/gui/widgets/HTMLWidget.java
@@ -134,7 +134,7 @@ public class HTMLWidget extends Widget {
     private class HTMLUpdater extends Thread {
 
         volatile boolean keepRunning = true;
-        private String url = null;
+        private volatile String url = null;
         private volatile int updateIntervalInSeconds = 24*3600;
 
         public void run() {
@@ -178,6 +178,7 @@ public class HTMLWidget extends Widget {
                     }
                     Thread.sleep(updateIntervalInSeconds*1000);
                 } catch (InterruptedException e) {
+                	//This is when the thread gets interrupted when it is sleeping.
                 	EfaUtil.foo();            
                 } catch (Exception e) {
                 	Throwable t = e.getCause();
@@ -199,8 +200,9 @@ public class HTMLWidget extends Widget {
             this.interrupt();
         }
 
-        public void stopHTML() {
+        public synchronized void stopHTML() {
             keepRunning = false;
+            interrupt(); // wake up thread
         }
 
     }

--- a/de/nmichael/efa/gui/widgets/MeteoAstroWidget.java
+++ b/de/nmichael/efa/gui/widgets/MeteoAstroWidget.java
@@ -413,6 +413,7 @@ public class MeteoAstroWidget extends Widget {
 
     public void stop() {
         try {
+        	// stopHTML also lets the thread die, and efaBths is responsible to set up a new thread.
             htmlUpdater.stopHTML();
         } catch(Exception eignore) {
             // nothing to do, might not be initialized
@@ -772,20 +773,24 @@ public class MeteoAstroWidget extends Widget {
 
                     // Use Swing thread-safe update method instead
                     SwingUtilities.invokeLater(new UpdateHtmlMeteoPaneRunner(htmlPane,htmlDoc.toString()));
-                } catch(Exception e) {
+                } 
+                catch(Exception e) {
                     Logger.logdebug(e);
                 }
 
                 try {
                     Thread.sleep(Math.max(updateIntervalInSeconds, 3600) * 1000);
-                } catch(Exception e) {
+                } catch (InterruptedException e) {
+                	EfaUtil.foo();
+                }catch(Exception e) {
                     Logger.logdebug(e);
                 }
             }
         }
         
-        public void stopHTML() {
+        public synchronized void stopHTML() {
             keepRunning = false;
+            interrupt(); // wake up thread
         }
 
         private String saveImage(String image, String format) {

--- a/eou/eou.xml
+++ b/eou/eou.xml
@@ -52,6 +52,7 @@
             <ChangeItem>BugFix: Swing Multithreading Problemm gelöst bei automatischem Fahrtenbuchwechsel, periorischem oder geplanten efaBths Neustart und Aktualisierung des efaCloud status im Fenstertitel.</ChangeItem>
             <ChangeItem>BugFix: Dialog für automatisches Beenden/Neustarten von efa zeigt den Grund korrekt an.</ChangeItem>
             <ChangeItem>BugFix: Resource Leak behoben: Die während eines Backups erstellte ZIP-Datei wird nach Abschluss geschlossen.</ChangeItem>
+			<ChangeItem>BugFix: News- und Uhr Widgets laufen im Hintergrund nicht weiter, wenn sie nicht sichtbar sind.</ChangeItem>
             <ChangeItem>BugFix: efaCloud: Verbesserungen der Synchronisation: bei Re-Synchronisation 'kürzlich' geänderter/neuer Datensätze berücksichtigt nur noch Datensätze der letzten 5 Tage statt 30 Tage.</ChangeItem>
             <ChangeItem>BugFix: efaCloud: Verbesserungen der Synchronisation: Besserer Umgang mit der Situation, wenn die Klartext-Namen durch UUIDs ersetzt werden (durch Aufräumarbeiten am Jahresende).</ChangeItem>
             <ChangeItem>BugFix: efaCloud: Projekt kann nicht mehr mit leeren Feldern zu efaCloud-Credentials in ein efaCloud-Projekt umgestellt werden.</ChangeItem>
@@ -104,6 +105,7 @@
             <ChangeItem>BugFix: Fixed swing multithreading problem when performing automatic logbook change, exiting efa due to periodic or planned restart, and updating efaCloud status in the title bar.</ChangeItem>
             <ChangeItem>BugFix: Dialog for automatic shutdown/restart of efa now shows the reason.</ChangeItem>
             <ChangeItem>BugFix: Removed resource leak: ZIP file created during a backup gets closed afterwards.</ChangeItem>
+			<ChangeItem>BugFix: Widgets for clock and news stop running in background if invisible.</ChangeItem>
 			<ChangeItem>BugFix: efaCloud: Sync improvements: when resyncing 'recently' changed/created records only records of the last 5 days are considered, instead of the last 30 days.</ChangeItem>
             <ChangeItem>BugFix: efaCloud: Sync improvements: better handling when names of boats and other items get replaced by uuids (by cleaning actions at the end of the year).</ChangeItem>
             <ChangeItem>BugFix: efaCloud: Cannot convert an existing project to efaCloud then efaCloud credential fields are empty</ChangeItem>


### PR DESCRIPTION
Summary
------
- Bugfix: News widget: NewsUpdater thread was busy in Background, if widget is invisible.
- Bugfix: News widget: changed texts did not show up after saving preferences, when the text fit 100% into the label space.
- Bugfix: Clock widget: ClockUpdater thread was busy in background, if widget is invisible.
- Bugfix: MeteoAstroWidget had multiple updater threads in background (each time after quitting admin dialog, a new MeteoAstro HMTL Updater Thread was created, but the latter did not stop)
- Every Widget thread now catches interruptedException.