### PR TITLE
Bugfixes

### DIFF
--- a/de/nmichael/efa/gui/EfaBaseFrame.java
+++ b/de/nmichael/efa/gui/EfaBaseFrame.java
@@ -4443,13 +4443,12 @@ public class EfaBaseFrame extends BaseDialog implements IItemListener {
          * (so the user started "start session" without choosing a boat or a person in advance */
         if (item != null && (item.boat != null || item.person!=null)) {
         	efaBoathouseSetPersonAndBoat(item);
-        	setRequestFocus(date);
-        } else {
-        	if (Daten.efaConfig.getValueEfaDirekt_eintragPresentLastTripOnNewEntry()) {
+        } else if (Daten.efaConfig.getValueEfaDirekt_eintragPresentLastTripOnNewEntry()) {
 	        	efaBoathouseSetDataFromLatestSession();
-	        	setRequestFocus(boat);
-        	}
+	            setRequestFocus(boat);
         }
+
+
         
         distance.parseAndShowValue("");
         updateTimeInfoFields();

--- a/de/nmichael/efa/gui/EfaBoathouseFrame.java
+++ b/de/nmichael/efa/gui/EfaBoathouseFrame.java
@@ -182,10 +182,12 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
     JPanel centerPanel = new JPanel();
     JPanel northPanel = new JPanel();
     JPanel southPanel = new JPanel();
+    
 
     // Window GUI Items
     JLabel titleLabel = new JLabel();
-
+    JButton closeButton;
+    
     // Data
     EfaBoathouseBackgroundTask efaBoathouseBackgroundTask;
     CrontabThread crontabThread;
@@ -452,7 +454,7 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
                 titleLabel.setHorizontalTextPosition(SwingConstants.LEFT);
                 titleLabel.setIconTextGap(20);
                 titleLabel.setBackground(bgColor);
-                JButton closeButton = new JButton();
+                closeButton = new JButton();
                 closeButton.setIcon(getIcon(ImagesAndIcons.IMAGE_FRAME_CLOSE ));
                 closeButton.setBackground(bgColor);
                 closeButton.setForeground(Color.white);
@@ -2656,6 +2658,13 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
             updateGuiElements();
             iniGuiHeaderColors();
             iniGuiTooltipDelays();
+            if (Daten.isApplEfaBoathouse() && Daten.isEfaFlatLafActive() && (closeButton!=null)) {
+                //EfaFlatLaf gets renitialized when efaConfig Dialog gets closed. 
+            	//this makes the closebutton in the blue header to get a border, and thus it grows.
+            	//we revoke the border when closing admin mode, then.
+                closeButton.setFont(closeButton.getFont().deriveFont(10f));
+                closeButton.setBorder(null);
+            }
         } finally {
             Daten.applMode = Daten.APPL_MODE_NORMAL;
         }

--- a/de/nmichael/efa/themes/EfaFlatLafHelper.java
+++ b/de/nmichael/efa/themes/EfaFlatLafHelper.java
@@ -65,6 +65,13 @@ public class EfaFlatLafHelper {
         	myCustomSettings.put("@efaTableHeaderBackground", "#"+EfaUtil.getColor(Daten.efaConfig.getTableHeaderBackgroundColor()));
         	myCustomSettings.put("@efaTableHeaderForeground", "#"+EfaUtil.getColor(Daten.efaConfig.getTableHeaderHeaderColor()));
         	myCustomSettings.put("@efaFocusColor", "#"+EfaUtil.getColor(Daten.efaConfig.getEfaGuiflatLaf_FocusColor()));
+        	if (Daten.efaConfig.getValueEfaDirekt_tabelleAlternierendeZeilenFarben()==false) {
+        		// Flatlaf looks cleaner when it uses no lines for tables. 
+        		// but then it needs alternating row colors to keep the rows apart.
+        		// so if no alternating rowcolors are active, we at least show horizontalLines.
+        		myCustomSettings.put("Table.showHorizontalLines", "true");
+        	}
+        		
         	//setting flatLaf efaTableAlternateRowColor will ENABLE alternate row color styling in flatlaf.
         	//efa itself has a special tableCellRenderer which supports alternate row coloring, and this cell renderer is NOT active
         	//for displaying the big logbook dialogue available in efaBths. 
@@ -86,6 +93,7 @@ public class EfaFlatLafHelper {
         	
         	//inform Flatlaf about custom settings
         	myLaf.setExtraDefaults(myCustomSettings); 
+        
         	
         	if (Daten.lookAndFeel.endsWith(Daten.LAF_EFAFLAT_LIGHT)) {
 	        	EfaFlatLightLookAndFeel.setup(myLaf);
@@ -95,6 +103,7 @@ public class EfaFlatLafHelper {
 	        	EfaFlatDarkLookAndFeel.setup(myLaf);
 	        	EfaFlatDarkLookAndFeel.updateUILater();
         	}
+        	
         }
     	
     }	


### PR DESCRIPTION
- Fixed: runefa.sh now again with unix-style line breaks
- Fixed: When flatlaf is active, saving efaConfig elements activate the new settings. this lead to a border for the X button in the blue efaBths title area. Now the border gets reset, if the user logs out from admin mode.
- if FlatLaf is active, and alternating row colors are disabled, tables show horizontal lines
- ShowLogbook dialog shows tooltips if a cell item does not fit (except for the crew column)