### PR TITLE
Bugfix and updated Version Number to 2.4.0

### DIFF
--- a/de/nmichael/efa/Daten.java
+++ b/de/nmichael/efa/Daten.java
@@ -70,9 +70,9 @@ import de.nmichael.efa.util.Logger;
 // @i18n complete
 public class Daten {
 
-	public final static String VERSION = "2.3.4 Beta Flatlaf 1905"; // Version für die Ausgabe (z.B. 2.1.0, kann aber
+	public final static String VERSION = "2.4.0 Beta Flatlaf 1945"; // Version für die Ausgabe (z.B. 2.1.0, kann aber
 																	// auch Zusätze wie "alpha" o.ä. enthalten)
-	public final static String VERSIONID = "2.3.4_#5"; // VersionsID: Format: "X.Y.Z_MM"; final-Version z.B. 1.4.0_00;
+	public final static String VERSIONID = "2.4.0_#5"; // VersionsID: Format: "X.Y.Z_MM"; final-Version z.B. 1.4.0_00;
 														// beta-Version z.B. 1.4.0_#1
 	public final static String VERSIONRELEASEDATE = "16.01.2024"; // Release Date: TT.MM.JJJJ
 	public final static String MAJORVERSION = "2";

--- a/de/nmichael/efa/gui/ShowLogbookDialog.java
+++ b/de/nmichael/efa/gui/ShowLogbookDialog.java
@@ -480,6 +480,7 @@ public class ShowLogbookDialog extends BaseDialog implements IItemListener {
                     }
                 }
             } catch (Exception ee) {
+            	Logger.logdebug(ee);
             }
             super.valueChanged(e);
         }
@@ -511,6 +512,7 @@ public class ShowLogbookDialog extends BaseDialog implements IItemListener {
 					}
 	            }            
 	        } catch (Exception eignore) {
+	        	Logger.logdebug(eignore);
 	        }
 	        return null;
 	    }
@@ -580,6 +582,7 @@ public class ShowLogbookDialog extends BaseDialog implements IItemListener {
 					}
 	            }            
 	        } catch (Exception eignore) {
+	        	Logger.logdebug(eignore);
 	        }
 	        return null;
 	    }        
@@ -619,6 +622,7 @@ public class ShowLogbookDialog extends BaseDialog implements IItemListener {
                 ((MyNestedJTable) value).setStartWithOddRow(row % 2 == 1);
                 return (Component) value;
             } catch (Exception e) {
+            	Logger.logdebug(e);
                 return null;
             }
         }
@@ -640,12 +644,11 @@ public class ShowLogbookDialog extends BaseDialog implements IItemListener {
 	            Color bkgColor = null;
 	            Color fgColor = null;
 	            
-                if (((TableItem) value).isBold()) {
+                if (value !=null && ((TableItem) value).isBold()) {
                     c.setFont(c.getFont().deriveFont(Font.BOLD));
                 }
 
                 if (this.useAlternatingColor) {
-    	            
                 	if (table instanceof MyNestedJTable) {
                 		Boolean startsWithOdd=((MyNestedJTable) table).getStartWithOddRow();
                 		if (startsWithOdd) {
@@ -673,6 +676,7 @@ public class ShowLogbookDialog extends BaseDialog implements IItemListener {
 	            c.setForeground(fgColor);
                 return this;
             } catch (Exception e) {
+            	Logger.logdebug(e);
                 return null;
             }
         }

--- a/eou/eou.xml
+++ b/eou/eou.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <efaOnlineUpdate>
 	<Version>
-        <VersionID>2.3.4_00</VersionID>
+        <VersionID>2.4.0_00</VersionID>
         <ReleaseDate>TODO</ReleaseDate>
-        <DownloadUrl>http://efa.nmichael.de/download/efa234.zip</DownloadUrl>
+        <DownloadUrl>http://efa.nmichael.de/download/efa240.zip</DownloadUrl>
         <DownloadSize>TODO</DownloadSize>
         <Changes lang="de">
 			<ChangeItem>Neu: EfaFlatLight LookAndFeel bietet eine klare, modernere Darstellung. In weiten Bereichen konfigurierbar.</ChangeItem>
@@ -58,7 +58,8 @@
             <ChangeItem>BugFix: emil: Einheitliche Höhe für Textfelder. Textfelder können nicht mehr zu klein sein in bestimmten LookAndFeels. Schnellere Scrollgeschwindigkeit in der Teilnehmerliste.</ChangeItem>
 			<ChangeItem>Bugfix: Keine Exception im Admintask zur Berechnung des Vereinsarbeit-Übertrags mehr, wenn zu einem Projekt ohne Vereinsarbeit gewechselt wird.</ChangeItem>
 			<ChangeItem>Bugfix: Bei aktivem Tooltip-Support zeigen Tabellen auch Tooltips für Spaltenüberschriften.</ChangeItem>
-			<ChangeItem>Bugfix: Fahrtenbuch anzeigen zeigt breitere Spalten für Datum- und Zeitfelder an (gut bei Verwendung größerer Schriftarten)</ChangeItem>
+			<ChangeItem>Bugfix: Fahrtenbuch anzeigen: zeigt breitere Spalten für Datum- und Zeitfelder an (gut bei Verwendung größerer Schriftarten)</ChangeItem>
+			<ChangeItem>Bugfix: Fahrtenbuch anzeigen: Darstellungsfehler behoben, wenn die Crew eines Fahrtenbucheintrags leer war.</ChangeItem>
 			<ChangeItem>Bugfix: Admin Modus: Dialoge zur Auswahl von Projekten, Fahrtenbüchern, Vereinsarbeit, Plugins werden besser dargestellt in allen LookAndFeels.</ChangeItem>
 			<ChangeItem>Bugfix: efaBths: Blaue Titelleiste verändert ihre Größe nicht mehr, wenn efaFlatLaf aktiv ist, und die efa-Konfiguration geändert wurde.</ChangeItem>
 			<ChangeItem>Bugfix: Tabellen: Wenn alternierende Zeilen aktiv sind, zeigt das efaFlatLaf zumindest horizontale Linien in den Tabellen an.</ChangeItem>        
@@ -119,7 +120,8 @@
 			<ChangeItem>BugFix: Widgets for clock and news stop running in background if invisible.</ChangeItem>
 			<ChangeItem>Bugfix: no exception in admintask for carryover calculation when changing project to a project where no clubwork has been defined in efabase.</ChangeItem>            
 			<ChangeItem>Bugfix: When tooltips are active for tables, tooltips are shown for table column headers.</ChangeItem>
-			<ChangeItem>Bugfix: Show Logbook dialog shows date and time colums with a larger width.</ChangeItem>
+			<ChangeItem>Bugfix: Show Logbook dialog: shows date and time colums with a larger width.</ChangeItem>
+			<ChangeItem>Bugfix: Show Logbook dialog: Fixed a rendering error when the crew of the logbook entry is empty.</ChangeItem>
 			<ChangeItem>Bugfix: Admin mode: Dialogs for selecting Projects, Logbooks, Clubwork, Plugins are better readable in any LookAndFeels.</ChangeItem>
 			<ChangeItem>Bugfix: efaBths: Blue title bar does not change it's size when efaFlatLaf is active and config items get saved in admin mode.</ChangeItem>
 			<ChangeItem>Bugfix: Tables: when alternating row colors are deactivated, flatlaf shows horizontal lines for better readability in tables.</ChangeItem>        


### PR DESCRIPTION
- Bugfix in ShowLogBookDialog when the crew of the logbook item was empty.
- updated efa version number to 2.4.0 - the higher version number is acceptable (taking into account the sheer ammount of features and bug fixes concerning LookAndFeel and stability issues).