### PR TITLE
Small bugfix, Club logo up to 320x200

### DIFF
--- a/de/nmichael/efa/Daten.java
+++ b/de/nmichael/efa/Daten.java
@@ -70,11 +70,11 @@ import de.nmichael.efa.util.Logger;
 // @i18n complete
 public class Daten {
 
-	public final static String VERSION = "2.4.0 Beta Flatlaf 2030"; // Version für die Ausgabe (z.B. 2.1.0, kann aber
+	public final static String VERSION = "2.4.0 Beta Flatlaf 1815"; // Version für die Ausgabe (z.B. 2.1.0, kann aber
 																	// auch Zusätze wie "alpha" o.ä. enthalten)
-	public final static String VERSIONID = "2.4.0_.5"; // VersionsID: Format: "X.Y.Z_MM"; final-Version z.B. 1.4.0_00;
+	public final static String VERSIONID = "2.4.0_.6"; // VersionsID: Format: "X.Y.Z_MM"; final-Version z.B. 1.4.0_00;
 														// beta-Version z.B. 1.4.0_#1  //# is not good, is used in efa.data.Waters 
-	public final static String VERSIONRELEASEDATE = "21.01.2024"; // Release Date: TT.MM.JJJJ
+	public final static String VERSIONRELEASEDATE = "11.02.2024"; // Release Date: TT.MM.JJJJ
 	public final static String MAJORVERSION = "2";
 	public final static String PROGRAMMID = "EFA.233"; // Versions-ID für Wettbewerbsmeldungen
 	public final static String PROGRAMMID_DRV = "EFADRV.233"; // Versions-ID für Wettbewerbsmeldungen

--- a/de/nmichael/efa/core/config/EfaConfig.java
+++ b/de/nmichael/efa/core/config/EfaConfig.java
@@ -1327,7 +1327,7 @@ public class EfaConfig extends StorageObject implements IItemFactory {
 					BaseTabbedDialog.makeCategory(CATEGORY_BOATHOUSE, CATEGORY_GUI),
 					International.getString("Sonstiges"), 3);
 
-			addParameter(efaDirekt_vereinsLogo = new ItemTypeImage("ClubLogo", "", 192, 64, IItemType.TYPE_PUBLIC,
+			addParameter(efaDirekt_vereinsLogo = new ItemTypeImage("ClubLogo", "", 320, 200, IItemType.TYPE_PUBLIC,
 					BaseTabbedDialog.makeCategory(CATEGORY_BOATHOUSE, CATEGORY_GUI ),
 					International.getString("Vereinslogo")));
 

--- a/de/nmichael/efa/core/items/ItemTypeImage.java
+++ b/de/nmichael/efa/core/items/ItemTypeImage.java
@@ -142,8 +142,8 @@ public class ItemTypeImage extends ItemType {
         String file = Dialog.dateiDialog(dlg,
                 International.getMessage("{item} auswählen",
                 getDescription()),
-                International.getString("Bild-Datei")+" (*.gif, *.jpg)",
-                "gif|jpg",
+                International.getString("Bild-Datei")+" (*.gif, *.jpg, *.png)",
+                "gif|jpg|png",
                 startDirectory, selectedFile, null,
                 false, false);
         if (file != null) {

--- a/de/nmichael/efa/gui/EfaBoathouseFrame.java
+++ b/de/nmichael/efa/gui/EfaBoathouseFrame.java
@@ -710,7 +710,14 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
             try {
                 logoLabel.setIcon(new ImageIcon(Daten.efaConfig.getValueEfaDirekt_vereinsLogo()));
                 logoLabel.setMinimumSize(new Dimension(200, 80));
-                logoLabel.setPreferredSize(new Dimension(200, 80));
+                if (logoLabel.getIcon()!=null) {
+                	logoLabel.setPreferredSize(new Dimension(
+                				Math.max(200, logoLabel.getIcon().getIconWidth()), 
+                				Math.max(80, logoLabel.getIcon().getIconHeight())));
+                } else {
+                	logoLabel.setPreferredSize(new Dimension(200,80));
+                }
+                logoLabel.setMaximumSize(new Dimension(logoLabel.getWidth(),logoLabel.getHeight()));
                 logoLabel.setHorizontalAlignment(SwingConstants.CENTER);
                 logoLabel.setHorizontalTextPosition(SwingConstants.CENTER);
             } catch (Exception e) {

--- a/de/nmichael/efa/gui/ProgressDialog.java
+++ b/de/nmichael/efa/gui/ProgressDialog.java
@@ -19,7 +19,9 @@ import java.awt.event.*;
 
 public class ProgressDialog extends BaseDialog {
 
-    private ProgressTask progressTask;
+	private static final long serialVersionUID = 4155197013485180926L;
+
+	private ProgressTask progressTask;
     private JTextArea loggingTextArea;
     private JLabel currentStatusLabel;
     private JProgressBar progressBar;

--- a/de/nmichael/efa/gui/ShowLogbookDialog.java
+++ b/de/nmichael/efa/gui/ShowLogbookDialog.java
@@ -449,7 +449,7 @@ public class ShowLogbookDialog extends BaseDialog implements IItemListener {
         }
     }
 
-    class MyJTable extends JTable {
+    private class MyJTable extends JTable {
 
 		private static final long serialVersionUID = 7627514043061724774L;
 
@@ -519,6 +519,13 @@ public class ShowLogbookDialog extends BaseDialog implements IItemListener {
         
     }
 
+    /** 
+     * MyNestedJTable is a table which is placed into a single cell.
+     * It is used for the "Crew" column. 
+     * 
+     * For it's inner cells, it uses the background color of the row it is currently used.
+     * 
+     */
     private class MyNestedJTable extends JTable {
 
 		private static final long serialVersionUID = -1632568401117917149L;
@@ -652,9 +659,9 @@ public class ShowLogbookDialog extends BaseDialog implements IItemListener {
                 	if (table instanceof MyNestedJTable) {
                 		Boolean startsWithOdd=((MyNestedJTable) table).getStartWithOddRow();
                 		if (startsWithOdd) {
-                			bkgColor = (row % 2 == 0 ? null : alternateColor);
+                			bkgColor = null; //(row % 2 == 0 ? null : alternateColor);
                 		} else {
-            	            bkgColor = (row % 2 == 0 ? alternateColor : null);
+            	            bkgColor = alternateColor; // (row % 2 == 0 ? alternateColor : null);
                 		}
                 	} else {
                 		bkgColor = (row % 2 == 0 ? alternateColor : null);

--- a/de/nmichael/efa/gui/dataedit/StatisticsListDialog.java
+++ b/de/nmichael/efa/gui/dataedit/StatisticsListDialog.java
@@ -66,6 +66,8 @@ public class StatisticsListDialog extends DataListDialog {
             //this.markedCellBold = true;
         }
 
+        this.minColumnWidths = new int[] {70,0,0,150,130,130};                
+        
         if (admin != null && admin.isAllowedEditStatistics()) {
             actionText = new String[]{
                         ItemTypeDataRecordTable.ACTIONTEXT_NEW,

--- a/de/nmichael/efa/util/Dialog.java
+++ b/de/nmichael/efa/util/Dialog.java
@@ -479,7 +479,7 @@ public class Dialog {
             return null;
         }
         return (Window) frameStack.peek();
-    }
+    }	
 
     // (this,"Fahrtenbuchdatei erstellen","efa Fahrtenbuch (*.efb)","efb",Daten.fahrtenbuch.getFileName(),true);
     public static String dateiDialog(Window frame, String titel, String typen, String extension, String startdir, boolean save) {
@@ -498,12 +498,18 @@ public class Dialog {
             }
 
             if (typen != null && extension != null) {
-                int wo;
+            	int wo;
                 if ((wo = extension.indexOf("|")) >= 0) {
-                    String ext1, ext2;
+                    String ext1, ext2, ext3;
                     ext1 = extension.substring(0, wo);
                     ext2 = extension.substring(wo + 1, extension.length());
-                    dlg.setFileFilter((javax.swing.filechooser.FileFilter) new EfaFileFilter(typen, ext1, ext2));
+                    if ((wo = ext2.indexOf("|")) >=0) {
+                    	ext3 = ext2.substring(wo + 1, ext2.length());
+                    	ext2 = ext2.substring(0, wo);
+                        dlg.setFileFilter((javax.swing.filechooser.FileFilter) new EfaFileFilter(typen, ext1, ext2, ext3));
+                    } else {                    
+                    	dlg.setFileFilter((javax.swing.filechooser.FileFilter) new EfaFileFilter(typen, ext1, ext2));
+                    }
                 } else {
                     dlg.setFileFilter((javax.swing.filechooser.FileFilter) new EfaFileFilter(typen, extension));
                 }

--- a/de/nmichael/efa/util/EfaFileFilter.java
+++ b/de/nmichael/efa/util/EfaFileFilter.java
@@ -19,6 +19,7 @@ public class EfaFileFilter extends javax.swing.filechooser.FileFilter {
   String description = "";
   String ext1 = "";
   String ext2 = "";
+  String ext3 = "";
   int anz=0;
 
   public EfaFileFilter(String descr, String ext) {
@@ -28,14 +29,22 @@ public class EfaFileFilter extends javax.swing.filechooser.FileFilter {
   }
 
   public EfaFileFilter(String descr, String ext1, String ext2) {
-    description = descr;
-    this.ext1 = ext1.toUpperCase();
-    this.ext2 = ext2.toUpperCase();
-    anz=2;
-  }
+	    description = descr;
+	    this.ext1 = ext1.toUpperCase();
+	    this.ext2 = ext2.toUpperCase();
+	    anz=2;
+	  }
+
+  public EfaFileFilter(String descr, String ext1, String ext2, String ext3) {
+	    description = descr;
+	    this.ext1 = ext1.toUpperCase();
+	    this.ext2 = ext2.toUpperCase();
+	    this.ext3 = ext3.toUpperCase();
+	    anz=3;
+	  }
 
   public boolean accept (File f) {
-    return f.isDirectory() || f.getName().toUpperCase().endsWith(ext1) || (anz == 2 && f.getName().toUpperCase().endsWith(ext2));
+    return f.isDirectory() || f.getName().toUpperCase().endsWith(ext1) || (anz == 2 && f.getName().toUpperCase().endsWith(ext2)) || (anz == 3 && f.getName().toUpperCase().endsWith(ext3));
   }
 
   public String getDescription() {

--- a/eou/eou.xml
+++ b/eou/eou.xml
@@ -15,6 +15,7 @@
             <ChangeItem>Neu: EfaConfig: Tooltip-Farben sind konfigurierbar.</ChangeItem>
             <ChangeItem>Neu: EfaConfig: Neustrukturierung der Konfiguration mit Überschriften und Hinweisen zu einzelnen Konfigurationselementen.</ChangeItem>
             <ChangeItem>Neu: EfaConfig: Überschriftenfarbe kann auch für Registerkarten genutzt werden (Metal and WindowsClassic LookAndFeel).</ChangeItem>
+            <ChangeItem>Neu: EfaConfig: Vereins-Logo kann bis 320x200 Pixel gross werden.</ChangeItem>
 			<ChangeItem>Neu: EfaConfig: Beim Maximieren von Fenstern kann efa den Platzberdarf der Taskbars berücksichtigen</ChangeItem>
             <ChangeItem>Neu: EfaConfig: EfaBootshaus-&amp;Eingabe: Option zur vereinfachten Anlage mehrerer ähnlicher Fahrten hintereinander (Expertenmodus)</ChangeItem>
             <ChangeItem>Neu: Versteckte Elemente im Boots- und PersonenDialog zeigen ein Icon und einen Tooltip zu ihrem Status.</ChangeItem>
@@ -77,6 +78,7 @@
             <ChangeItem>New: EfaConfig: Tooltip colores customizable.</ChangeItem>
             <ChangeItem>New: EfaConfig: Restructuring of the configuration with headings and notes on individual configuration elements.</ChangeItem>
             <ChangeItem>New: EfaConfig: Heading colors can be used for highlighting tab headers (Metal and WindowsClassic LookAndFeel).</ChangeItem>
+            <ChangeItem>New: EfaConfig: Club logo can have a bigger size of 320x200 pixels.</ChangeItem>
 			<ChangeItem>New: EfaConfig: When maximizing windows, efa can respect taskbar size and location</ChangeItem>
             <ChangeItem>New: EfaConfig: efa-Boat House&amp;Input: New option to simplify input of multiple similar sessions (expert mode).</ChangeItem>
             <ChangeItem>New: efaBths: Clock widget and buttons use bold font, even if not setup in efaConfig.</ChangeItem>


### PR DESCRIPTION
Summary
------
The Logbook dialog which can be run from efaBths main screen did not look good if there were a lot of trips with more than two crew members. So alternating color for the crew table within a row has been deactivated.

Also, current monitors provide a lot of space when they are 16:10 or 16:9. The logo can consume more space and thus be bigger. So the logo can be up to 320x200 pixels.

The logo width affects the widths of the buttons in efaBths. So the wider the logo, the wider the widths of the buttons. This is intended; the user has to take care by himself that the look of efaBths is not affected badly by too big logos.

The FileOpenDialog now supports up to three file extensions. PNG file format has been added as it is supported by java 1.8+

StatisticsDialog now uses more pixels for the "number" column.