### PR TITLE
Reordered matching for determining default font

### DIFF
--- a/de/nmichael/efa/core/config/EfaConfig.java
+++ b/de/nmichael/efa/core/config/EfaConfig.java
@@ -3332,20 +3332,28 @@ public class EfaConfig extends StorageObject implements IItemFactory {
 		
 		String uiFontsString=uiFonts.toString().toLowerCase();
 		
+		/* the order is optimized for common operating systems:
+		 * - Arial, Segoe: -> Windows
+		 * - Piboto -> Raspian, efaLive for Raspberry Pi
+		 * - Liberation Sans -> Debian, efaLive for x86
+		 * - Roboto -> Linux systems like Ubuntu
+		 * - Noto Sans Display -> Linux systems like Ubuntu
+		 */
+		
 		if (uiFontsString.matches(".*arial.*")) {
 			return "Arial";
 		} else if (uiFontsString.matches(".*segoe.ui.*")){
 			return "Segoe UI";
 		} else if (uiFontsString.matches(".*piboto.*")) {
 			return "Piboto";		
+		} else if (uiFontsString.matches(".*liberation.sans*")) {
+			return "Liberation Sans";
+		} else if (uiFontsString.matches(".*roboto.*")) {
+			return "Roboto";				
 		} else if (uiFontsString.matches(".*noto.sans.display.*")) {
 			return "Noto Sans Display";			
 		} else if (uiFontsString.matches(".*noto.sans.*")) {
 			return "Noto Sans";		
-		} else if (uiFontsString.matches(".*roboto.*")) {
-			return "Roboto";				
-		} else if (uiFontsString.matches(".*liberation.sans*")) {
-			return "Liberation Sans";
 		}
 		return "Dialog";
 	}


### PR DESCRIPTION
Summary
--------------
efaLive distributions for Raspberry Pi and x86 systems differ concerning their installed fonts. So "Liberation Sans" as a commonly available font under linux systems (in special, efaLive) has been promoted to a higher priority.