### PR TITLE
Bugfix font detection for liberation sans

### DIFF
--- a/de/nmichael/efa/Daten.java
+++ b/de/nmichael/efa/Daten.java
@@ -1365,7 +1365,7 @@ public class Daten {
 		return false;
 	}
 
-	public static Vector getUIProperties() {
+	public static Vector <String>getUIProperties() {
 
 		Vector<String> infos = new Vector<String>();
 		UIDefaults uid = Dialog.getUiDefaults();
@@ -1386,7 +1386,7 @@ public class Daten {
 		return infos;
 	}
 
-	public static Vector getCSSInfo() {
+	public static Vector <String>getCSSInfo() {
 
 		Vector<String> infos = new Vector<String>();
 		HTMLEditorKit kit = new HTMLEditorKit();
@@ -1401,11 +1401,11 @@ public class Daten {
 		return infos;
 	}
 
-	public static Vector getEfaInfos() {
+	public static Vector <String>getEfaInfos() {
 		return getEfaInfos(true, true, true, true, false);
 	}
 
-	public static Vector getEfaInfos(boolean efaInfos, boolean pluginInfos, boolean javaInfos, boolean hostInfos,
+	public static Vector <String>getEfaInfos(boolean efaInfos, boolean pluginInfos, boolean javaInfos, boolean hostInfos,
 			boolean jarInfos) {
 		Vector<String> infos = new Vector<String>();
 

--- a/de/nmichael/efa/core/config/EfaConfig.java
+++ b/de/nmichael/efa/core/config/EfaConfig.java
@@ -3346,7 +3346,7 @@ public class EfaConfig extends StorageObject implements IItemFactory {
 			return "Segoe UI";
 		} else if (uiFontsString.matches(".*piboto.*")) {
 			return "Piboto";		
-		} else if (uiFontsString.matches(".*liberation.sans*")) {
+		} else if (uiFontsString.matches(".*liberation.sans.*")) {
 			return "Liberation Sans";
 		} else if (uiFontsString.matches(".*roboto.*")) {
 			return "Roboto";				

--- a/de/nmichael/efa/gui/EfaAboutDialog.java
+++ b/de/nmichael/efa/gui/EfaAboutDialog.java
@@ -169,7 +169,7 @@ public class EfaAboutDialog extends BaseDialog {
 	}	
 	
 	private void iniEfaSystemInfos() {
-		Vector infos = Daten.getEfaInfos();
+		Vector <String>infos = Daten.getEfaInfos();
         for (int i = 0; infos != null && i < infos.size(); i++) {
             efaInfosText.append((String) infos.get(i) + "\n");
         }
@@ -180,15 +180,22 @@ public class EfaAboutDialog extends BaseDialog {
         //Add GUI Debug info, if debug info is activated in efaConfig or by Commandline
         if (Logger.isDebugLogging()||Logger.isDebugLoggingActivatedByCommandLine()) {
 	        // Get UI Defaults Properties
+        	
+        	efaInfosText.append("\n\n\nDisplayFonts\n-------------\n");
+	        Vector<String> fonts = EfaUtil.makeFontFamilyVector(false, null);
+	        if (fonts!=null) {
+	        	efaInfosText.append(fonts.toString());
+	        }
+	        
         	efaInfosText.append("\n\n\nUIManager.getDefaults()\n-------------\n");
-	        Vector lafProperties = Daten.getUIProperties();
+	        Vector <String>lafProperties = Daten.getUIProperties();
 	        for (int i = 0; lafProperties != null && i < lafProperties.size(); i++) {
 	            efaInfosText.append((String) lafProperties.get(i) + "\n");
 	        }
 	        
 	        // Get HTML CSS Stylesheet Default Rules
 	        efaInfosText.append("\n\n\nHTMLEditorKit().getStyleSheet() rules\n-------------\n");
-	        Vector htmlCSSRules = Daten.getCSSInfo();
+	        Vector <String>htmlCSSRules = Daten.getCSSInfo();
 	        for (int i = 0; htmlCSSRules != null && i < htmlCSSRules.size(); i++) {
 	            efaInfosText.append((String) htmlCSSRules.get(i) + "\n");
 	        }


### PR DESCRIPTION
The font "Liberation Sans" which is an Arial like font did not work correctly due to a typo in a regExp in efaConfig.

Added Debug info in efaAbout Dialog concerning Display fonts (if efa is in debug mode) and fixed some warnings in Daten.java