### PR TITLE
Update Waters.java

### DIFF
--- a/de/nmichael/efa/data/Waters.java
+++ b/de/nmichael/efa/data/Waters.java
@@ -27,6 +27,7 @@ import java.util.*;
 public class Waters extends StorageObject {
 
     public static final String DATATYPE = "efa2waters";
+    private static final String HASH_DELIMITER = "|"; // shall not be # as it conflicts with version field in Daten.java
 
     public Waters(int storageType, 
             String storageLocation,
@@ -196,17 +197,17 @@ public class Waters extends StorageObject {
         if (oldHash == null || oldHash.length() == 0) {
             return true; // never checked
         }
-        String oldv = oldHash.indexOf("#") > 0 ? oldHash.substring(0, oldHash.indexOf("#")) : oldHash;
+        String oldv = oldHash.indexOf(HASH_DELIMITER) > 0 ? oldHash.substring(0, oldHash.indexOf(HASH_DELIMITER)) : oldHash;
         if (Daten.VERSIONID.compareTo(oldv) <= 0) {
             return false; // already checked for this version, don't check again
         }
         String newh = getWatersTemplateHash(countryCode);
-        String oldh = oldHash.indexOf("#") > 0 ? oldHash.substring(oldHash.indexOf("#")+1) : oldHash;
+        String oldh = oldHash.indexOf(HASH_DELIMITER) > 0 ? oldHash.substring(oldHash.indexOf(HASH_DELIMITER)+1) : oldHash;
         return !oldh.equals(newh);
     }
     
     public static void setWaterTemplateUnchanged(String countryCode) {
-        Daten.project.setLastWatersTemplateHash(Daten.VERSIONID + "#" + getWatersTemplateHash(countryCode));
+        Daten.project.setLastWatersTemplateHash(Daten.VERSIONID + HASH_DELIMITER + getWatersTemplateHash(countryCode));
     }
 
     public synchronized int addAllWatersFromTemplate(String countryCode) {
@@ -220,7 +221,7 @@ public class Waters extends StorageObject {
             String water = null;
             while ( (s = f.readLine()) != null) {
                 s = s.trim();
-                if (s.length() == 0 || s.startsWith("#")) {
+                if (s.length() == 0 || s.startsWith("#")) { //# in this code is used for delimiting multiple items for a water.
                     continue;
                 }
                 


### PR DESCRIPTION
Summary
-----------
Efa determines automatically if a new waters file is present (in its JAR). If yes, it asks to update the waters once admin mode is opened.

When running a beta belease (2.4.1_#1), the beta is marked by an # character.

This conflicts with the automatic recognition of efa for new waters files, as the # is used there for splitting last version number and a water's MD5 hash.

The water's MD5 hash get a different delimiter (|) so that beta versions of efa can use the former template (2.4.1_#1).