### PR TITLE
Update TxRequestQueue.java

### DIFF
--- a/de/nmichael/efa/data/efacloud/TxRequestQueue.java
+++ b/de/nmichael/efa/data/efacloud/TxRequestQueue.java
@@ -28,7 +28,6 @@ import de.nmichael.efa.gui.EfaBaseFrame;
 import de.nmichael.efa.gui.EfaBoathouseFrame;
 import de.nmichael.efa.gui.EfaCloudConfigDialog;
 import de.nmichael.efa.gui.ImagesAndIcons;
-import de.nmichael.efa.util.EfaUtil;
 import de.nmichael.efa.util.International;
 import de.nmichael.efa.util.Logger;
 
@@ -83,7 +82,7 @@ public class TxRequestQueue implements TaskManager.RequestDispatcherIF {
     // The update period MUST be at least 5 times the InternetAccessManager timeout.
     // The synchronisation start delay is one SYNCH_PERIOD
     static final int SYNCH_PERIOD_DEFAULT = 3600000; // = 3600 seconds = 1 hour
-    static final long SYNCHRONIZATION_TIMEOUT = 180000; // the synchronisation will be forced to end after this time
+    static final long SYNCHRONIZATION_TIMEOUT = 15*60*1000; // the synchronisation will be forced to end after this time - 15 minutes
     static int synch_period = SYNCH_PERIOD_DEFAULT; // = 3600 seconds = 1 hour
     static final int STATS_UPLOAD_PERIOD_MIN = 86400000;  // = 86400 seconds = 24 hours
 
@@ -826,6 +825,8 @@ public class TxRequestQueue implements TaskManager.RequestDispatcherIF {
                 // ============== time out for synchronization ======
                 if ((txq.getState() == TxRequestQueue.QUEUE_IS_SYNCHRONIZING)
                         && ((System.currentTimeMillis() - synchControl.lastSynchStartedMillis) > SYNCHRONIZATION_TIMEOUT)) {
+                	//TODO: Code is buggy. See https://github.com/nicmichael/efa/issues/257 for more info.
+                	//(Upload) Sync currently will not be stopped after the sync timeout.
                     txq.registerStateChangeRequest(TxRequestQueue.RQ_QUEUE_RESUME);
                     txq.logApiMessage("Synchronization Timeout. "
                              + International.getString("Die Synchronisation wird beendet."), 1);


### PR DESCRIPTION
Initial Problem:
-------------------
When setting up a new efacloud project (with uploading all data of a formerly 'local' efa2 project), there could be errors.
One way to provoke them was to
- delete the very first logbook item BEFORE upgrading the project to efaCloud
- make the project an efaCloud project, restart efa, wait for first download sync (checkmark available in window title) and run an upload synchronisation.
- do NOT perform a restart of efa.
- after succeeded upload synchronisation, delete a message or a boat reservation
- after succeeded upload synchronisation, edit a logbook record (e.g. number#10)

Then there was a good chance that deleting a message would delete the wrong one and leaving behind some emtpy messages which can no longe be deleted, or that the edit of logbook record #10 would update record#9 instead.

This is because efaCloud renumbers messages, logbook records, boatdamages etc, to fill up empty spaces in the numbering.
If e.g. the very first logbook record#1 gets deleted before the very first upload sync, all other logbook records will get a new number, beginning from #1.

The origin of the problem is that in efa 2.4.1, by pull requests https://github.com/nicmichael/efa/pull/216, https://github.com/nicmichael/efa/pull/217, https://github.com/nicmichael/efa/pull/222, an Ecrid index got introduced in efa. 

This index was initialized on startup (loading all ecrids of the data files of an efaCloud project), and would keep the ecrids alongside an object representing the actual record. This Index would never get an update if the record behind the ecrid would get an update, even not if it was the efa2 unique id item that changed (like session number for logbooks, which may be updated by efaCloud server). This could lead to the problems described above.

Also, the Ecrid index would not be cleared when an efacloud datafile was closed, reserving memory and <i>possibly<i> messing up records which may have the identical ecrid in diffrent efacloud projects.

Solution (Summary)
----------------
- The Ecrid index gets updates when the respective records get an update from the efacloud server. 
- Also, when closing an efacloud datafile, the respective items get removed from the Ecrid index
- Logging for ecrid creation, adding, removing and updating items in the Ecrid index is established in debug mode, on TRACE_TOPIC 40000. Trace level 1 is generic logging about the Ecrid index elements after opening/closing datafiles. Trace level 6 is very intense logging about creating ecrids, adding, updateing and removing items from the Ecrid index.

Solution (Details)
----------------------
- Moved efaCloud changes in DataFile.Java to efaCloudStorage.java to keep datafile.java free from efaCloud code.
So the standard datafile for 'local' projects does not need to know about efaCloud specifics, but contains stubs for calling methods in subclasses like efaCloudStorage.java.
- The actual efaCloud code for datafile.java has been moved to efaCloudStorage.java.
- efaCloud clears ecrids on closing of datastorage
- efacloud updates ecrids when they are updated from the server
- efacloud removes ecrids when records are deleted.

- A specific TraceTopic has been established for efaCloud logging (0x40000), so that the provided debug logging can be controlled by enabling a TraceTopic of 40000 and a TraceLevel of 1 or 6.

- EfaBoathouseBackgroundTask does not do any modifications on records, when admin mode is active, or a shutdown of efa is requested. This helps a lot, as this task would re-open some datafiles for persons, boatstatuses, boats, boatreservations, if they are already closed.

- an obvious error in TableBuilder.java was fixed, efa2clubwork was missing in the list of tables which have an ecrid.

- runefa.bat / .sh has been updated so that efa has 32 MB more of RAM to store project data.
It showed that efa opens (and closes) datafiles more frequently than thought, for instance when choosing a logbook or a clubwork item, a lot of datafiles get opened (loaded) and closed afterwards. As the ecrid index holds the records of each datafile, some more RAM should be available for efa.

Remaining bugs, left for future fixing
--------------------
- when an upload sync takes place, and the user tries to change the current project, logbook or clubwork,
it is likely that efa2 ends in a deadlock situation: efa2 tries to close the current logbook, clubwork, ..., but the background tasks of efaCloud do not allow that.

A possible solution would be that the corresponding menu items/buttons in efaBase and efaBoathouse do check wether a sync is currently running in background, and would not show the respective dialog.

- the Ecrid Index as well as the efaCloud TXRequestQueue and Sync threads are singletons. As efa is quite prone to opening and closing projects on certain actions, singletons do not look like a good idea, but should better be singletons within a project (than globally in efa2) 


Addendum:
-----------
Set efacloud upload sync timeout to 15 minutes (after discussion with Martin Glade).

This leads to less entries in efaloud.log that the sync has timed out and will be cancelled (but obivously, it is not cancelled due to the bug).

The timeout handling does currently not work, but an update would be rather complex. So this needs to be done in another feature. An issue has been documented on GitHub.