### PR TITLE
Mn efa 126 show sessions of other logbooks

### DIFF
--- a/de/nmichael/efa/core/config/EfaConfig.java
+++ b/de/nmichael/efa/core/config/EfaConfig.java
@@ -266,6 +266,7 @@ public class EfaConfig extends StorageObject implements IItemFactory {
 	private ItemTypeBoolean efaDirekt_mitgliederDuerfenNamenHinzufuegen;
 	private ItemTypeBoolean efaDirekt_resBooteNichtVerfuegbar;
 	private ItemTypeBoolean efaDirekt_wafaRegattaBooteAufFahrtNichtVerfuegbar;
+	private ItemTypeBoolean efaDirekt_boatListShowForeignLogbookSessionsAsNotAvailable;
 	private ItemTypeInteger efaDirekt_resLookAheadTime;
 	private ItemTypeString efaDirekt_execOnEfaExit;
 	private ItemTypeTime efaDirekt_exitTime;
@@ -1380,6 +1381,12 @@ public class EfaConfig extends StorageObject implements IItemFactory {
 					BaseTabbedDialog.makeCategory(CATEGORY_BOATHOUSE, CATEGORY_GUI),
 					International.getString(
 							"Boote auf Regatta, Trainingslager oder Mehrtagesfahrt als 'nicht verfügbar' anzeigen")));
+			addParameter(efaDirekt_boatListShowForeignLogbookSessionsAsNotAvailable = new ItemTypeBoolean(
+					"BoatListShowForeignLogbookSessionsAsNotAvailable", true, IItemType.TYPE_PUBLIC,
+					BaseTabbedDialog.makeCategory(CATEGORY_BOATHOUSE, CATEGORY_GUI),
+					International.getString(
+							"Boote, die in anderen Fahrtenbüchern unterwegs sind, als 'nicht verfügbar' anzeigen")));
+			
 			addParameter(efaDirekt_boatsNotAvailableListSize = new ItemTypeInteger("BoatsNotAvailableListSize", 200,
 					100, 600, IItemType.TYPE_EXPERT,
 					BaseTabbedDialog.makeCategory(CATEGORY_BOATHOUSE, CATEGORY_GUI),
@@ -2400,6 +2407,10 @@ public class EfaConfig extends StorageObject implements IItemFactory {
 		return efaDirekt_wafaRegattaBooteAufFahrtNichtVerfuegbar.getValue();
 	}
 
+	public boolean getValueEfaDirekt_boatListShowForeignLogbookSessionsAsNotAvailable() {
+		return efaDirekt_boatListShowForeignLogbookSessionsAsNotAvailable.getValue();
+	}
+	
 	public int getValueEfaDirekt_resLookAheadTime() {
 		return efaDirekt_resLookAheadTime.getValue();
 	}

--- a/de/nmichael/efa/core/items/ItemTypeList.java
+++ b/de/nmichael/efa/core/items/ItemTypeList.java
@@ -71,6 +71,7 @@ public class ItemTypeList extends ItemType implements ActionListener, DocumentLi
     JScrollPane scrollPane;
     JList list = new JList();
     JTextField filterTextField;
+    EfaMouseListener popupListener; 
     JPopupMenu popup;
     Long lastFilterChange=0l;
     DefaultListModel<ItemTypeListData> data; // no longer Vector as we need a DefaultListModel for filtering
@@ -225,7 +226,7 @@ public class ItemTypeList extends ItemType implements ActionListener, DocumentLi
      * - right row gets remaining space and is truncated on the right side, if contents do not fit.
      *   also, right row contents are rendered in grey text color.
      */
-private String getHTMLTableFor(String firstPart, String secondPart, boolean isSelected) {
+    private String getHTMLTableFor(String firstPart, String secondPart, boolean isSelected) {
     	
 		// we only build an HTML table, if there is a secondPart to be displayed.
 	    // building html tables takes a lot of time on a raspberry pi 3b with a boat list
@@ -481,6 +482,20 @@ private String getHTMLTableFor(String firstPart, String secondPart, boolean isSe
 
     public void setPopupActions(String[] actions) {
         this.actions = actions;
+        // if a popup menu already exists, remove all elements and rebuild the popup menu.
+        if (popup!=null) {
+	        popup.removeAll();
+	        for (int i = 0; actions != null && i < actions.length; i++) {
+	            JMenuItem menuItem = new JMenuItem(actions[i].substring(1));
+	            menuItem.setActionCommand(EfaMouseListener.EVENT_POPUP_CLICKED + "_" + actions[i].substring(0, 1));
+	            menuItem.addActionListener(this);
+	            popup.add(menuItem);
+	            menuItem.setIcon(getIconFromActionID(actions[i].substring(0, 1)));
+	        }
+	        if (popupListener!=null) {
+	        	popupListener.setPopupMenu(popup);
+	        }
+        }
     }
 
     protected void iniDisplay() {
@@ -585,8 +600,8 @@ private String getHTMLTableFor(String firstPart, String secondPart, boolean isSe
 	            	}}});
         }
 
-        EfaMouseListener listener = new EfaMouseListener(list, popup, this, Daten.efaConfig.getValueEfaDirekt_autoPopupOnBoatLists());
-        list.addMouseListener(listener);
+        popupListener = new EfaMouseListener(list, popup, this, Daten.efaConfig.getValueEfaDirekt_autoPopupOnBoatLists());
+        list.addMouseListener(popupListener);
 
         list.addFocusListener(new java.awt.event.FocusAdapter() {
             public void focusGained(FocusEvent e) {

--- a/de/nmichael/efa/data/BoatStatusRecord.java
+++ b/de/nmichael/efa/data/BoatStatusRecord.java
@@ -241,13 +241,19 @@ public class BoatStatusRecord extends DataRecord {
      * @return Destination and DestinationVariant name
      */
     public String getDestination() {
-    	
-        LogbookRecord r = getLogbookRecord(); 	
-        if (r==null) {
-        	return International.getString("Fehler: kein Fahrtenbucheintrag zu Boot auf Fahrt");
-        } else {
-        	return r.getDestinationAndVariantName();
-        }
+   	
+    	if (getLogbook().equalsIgnoreCase(Daten.project.getCurrentLogbook().getName())) {
+    		LogbookRecord r = getLogbookRecord(); 	
+	    	if (r==null) {
+	        	return International.getString("Fehler: kein Fahrtenbucheintrag zu Boot auf Fahrt");
+	        } else {
+	        	return r.getDestinationAndVariantName();
+	        }
+    	} else {
+    		// boatstatus not in the current logbook, so only display sessionno and logbookname.
+    		// this is safe, as this data is in the boatstatus, and we do not load a "foreign" logbook on the fly
+    		return "#"+getEntryNoAndLogbook();
+    	}
     }    
     
     public void setOnlyInBoathouseId(int boathouseId) {

--- a/de/nmichael/efa/gui/util/EfaMouseListener.java
+++ b/de/nmichael/efa/gui/util/EfaMouseListener.java
@@ -21,6 +21,7 @@ public class EfaMouseListener extends MouseAdapter {
     public static final String EVENT_MOUSECLICKED_1x = "efa_mouseClicked1x";
     public static final String EVENT_MOUSECLICKED_2x = "efa_mouseClicked2x";
     public static final String EVENT_POPUP           = "efa_Popup";
+    public static final String EVENT_BUILD_POPUP_MENU= "efa_BuildPopupMenu";
     public static final String EVENT_POPUP_CLICKED   = "efa_PopupClicked";
 
     private Component myComponent;
@@ -81,6 +82,9 @@ public class EfaMouseListener extends MouseAdapter {
         if (e != null && e.getButton() == 1) {
             if (e.getClickCount() == 1) {
                 if (showPopupOnLeftMouseClick) {
+                    if (actionListener != null) {
+                        actionListener.actionPerformed(new ActionEvent(e.getSource(), ActionEvent.ACTION_PERFORMED, EVENT_BUILD_POPUP_MENU));
+                    }                 	
                     showPopup(e);
                 }
                 actionListener.actionPerformed(new ActionEvent(e.getSource(), ActionEvent.ACTION_PERFORMED, EVENT_MOUSECLICKED_1x));
@@ -96,12 +100,19 @@ public class EfaMouseListener extends MouseAdapter {
     private void maybeShowPopup(MouseEvent e) {
         try {
             if (popupsEnabled && e.isPopupTrigger()) {
+                if (actionListener != null) {
+                    actionListener.actionPerformed(new ActionEvent(e.getSource(), ActionEvent.ACTION_PERFORMED, EVENT_BUILD_POPUP_MENU));
+                } 
                 showPopup(e);
                 if (actionListener != null) {
                     actionListener.actionPerformed(new ActionEvent(e.getSource(), ActionEvent.ACTION_PERFORMED, EVENT_POPUP));
-                } 
+                }                 
             }
         } catch(Exception eignore) {
         }
+    }
+    
+    public void setPopupMenu(JPopupMenu value) {
+    	popup = value;
     }
 }

--- a/efa_de.properties
+++ b/efa_de.properties
@@ -325,6 +325,7 @@ Boot_{boat}_nicht_in_der_Statusliste_gefunden!=Boot {1} nicht in der Statusliste
 Boote=Boote
 Boote_auf_Fahrt=Boote auf Fahrt
 Boote_auf_Regatta,_Trainingslager_oder_Mehrtagesfahrt_als__nicht_verf\u00fcgbar__anzeigen=Boote auf Regatta, Trainingslager oder Mehrtagesfahrt als 'nicht verf\u00fcgbar' anzeigen
+Boote,_die_in_anderen_Fahrtenb\u00fcchern_unterwegs_sind,_als__nicht_verf\u00fcgbar__anzeigen=Boote, die in anderen Fahrtenb\u00fcchern unterwegs sind, als 'nicht verf\u00fcgbar' anzeigen
 Boote_bearbeiten=Boote bearbeiten
 Bootsart=Bootsart
 Bootsbenutzungs-Sperre=Bootsbenutzungs-Sperre

--- a/efa_en.properties
+++ b/efa_en.properties
@@ -308,6 +308,7 @@ Boot=Boat
 Boote=Boats
 Boote_auf_Fahrt=Boats on the Water
 Boote_auf_Regatta,_Trainingslager_oder_Mehrtagesfahrt_als__nicht_verf\u00FCgbar__anzeigen=Show boats which are on regatta, in a training camp or on a multi-day journey as 'not available'
+Boote,_die_in_anderen_Fahrtenb\u00fcchern_unterwegs_sind,_als__nicht_verf\u00fcgbar__anzeigen=Show boats which are 'on the water' in other logbooks as 'not available'
 Boote_bearbeiten=Edit Boats
 Bootsart=Boat Type
 Bootsbenutzungs-Sperre=Boat Usage Ban

--- a/efa_fr.properties
+++ b/efa_fr.properties
@@ -446,6 +446,7 @@ Boot_war_nicht_geputzt=Le bateau n'\u00E9tait pas nettoy\u00E9
 Boot=Bateau
 Boote_auf_Fahrt=Bateaux sortis
 Boote_auf_Regatta,_Trainingslager_oder_Mehrtagesfahrt_als__nicht_verf\u00FCgbar__anzeigen=Les bateaux en r\u00E9gate, en camp d'entra\u00EEnement ou en excursion sont montr\u00E9s comme 'non disponibles'
+Boote,_die_in_anderen_Fahrtenb\u00fcchern_unterwegs_sind,_als__nicht_verf\u00fcgbar__anzeigen=Les 'bateaux sortis' dans d'autres journaux de bord sont montr\u00E9s comme 'non disponibles'
 Boote_bearbeiten=Modifier le bateau
 Boote=Bateaux
 Bootsart=Type de bateau

--- a/eou/eou.xml
+++ b/eou/eou.xml
@@ -11,11 +11,13 @@
         <ShowNotice lang="en">If you use efaCloud, make sure your server at least supports efaCloud Version 2.3.3. It is recommended to upgrade to EfaCloud 2.4.0_10 or above.</ShowNotice>
         <Changes lang="de">
         	<ChangeItem>Neu: update runEfa.bat/.sh - 192MB RAM statt 160MB für efa JavaVM, wegen Speicher-Mehrbedarf für efaCloud.</ChangeItem>
+			<ChangeItem>Neu: Boote, die in anderen Logbüchern 'auf Fahrt' sind, können als 'nicht verfügbare Boote' angezeigt werden.</ChangeItem>
         	<ChangeItem>Bugfix: Auswahlliste für Personen wird aktualisiert, wenn bei Neuanlage einer Fahrt das Boot oder die Bootsvariante geändert wird.</ChangeItem>        	
         	<ChangeItem>Bugfix: efaCloud: Ecrid Index Handling verbessert: keine Probleme mehr nach dem Aufsetzen neuer efaCloud Systeme</ChangeItem>
         </Changes>
         <Changes lang="en">
         	<ChangeItem>New: update runEfa.bat/.sh - 192MB RAM instead of 160MB for efa JavaVM, due to higher demands for efaCloud.</ChangeItem>
+			<ChangeItem>New: Boats which are 'on the water' in other logbooks, can be shown as 'not available boats'</ChangeItem>
         	<ChangeItem>Bugfix: When changing the boat or boatvariant while creating a new session, the autocomplete list for persons get a refresh.</ChangeItem>        	
         	<ChangeItem>Bugfix: efaCloud: Ecrid index handling optimized: no more issues when setting up new efaCloud systems.</ChangeItem>
         </Changes>	


### PR DESCRIPTION
Solved issue
------------------
EFA#126 efaCloud: efa 2.4.1 only shows sessions of the current logbook [#254](https://github.com/nicmichael/efa/issues/254)

Problem
---------------
The former behaviour of efaBootshaus was that  all boatrecords with status "onthewater" were shown in this list - whether there was an logbook entry in the current logbook or not.

In efaCloud based projects, the former behaviour was prone to data loss when multiple boathouses were involved.
By now, efaCloud requires that the "boats on the water" list only shows boats from the current logbook.
This had been introduced in Nov. 2024, but lead to the issue that sessions which are still open are no longer visible to the user. 
This may occur when a logbook rotation took place, and not all still open sessions were aborted.

Solution
-----------
Boatstatuses "onthewater" which point to an logbook entry in a diffrent logbook can show up in the list of "unavailable boats". This is because the boats are actually not available for new sessions.

There is an option in efaConfig (Boathouse -> Appearance -> Boat lists: common settings which can remove those entries from the list of unavailable boats.

The popup menu options are now determined by the actual selected entry of the boat list, instead of having a static list of options in the popup solely based on the list type.

