### PR TITLE
Mn efa 129 efa restart on windows fix

### DIFF
--- a/de/nmichael/efa/Daten.java
+++ b/de/nmichael/efa/Daten.java
@@ -393,6 +393,29 @@ public class Daten {
 		} else {
 			Logger.log(Logger.INFO, Logger.MSG_CORE_HALT, International.getString("PROGRAMMENDE"));
 		}
+		
+		// On Windows systems, efa relies on java restart. So we need to take care of the java-based restart
+		// AFTER running the haltProgram code. Otherwise, the new efa instance may be run faster than the current one has shut down.
+		if (exitCode == Daten.HALT_JAVARESTART ) {
+            String restartargs = (Daten.efa_java_arguments != null ? Daten.efa_java_arguments
+                    : "-cp " + System.getProperty("java.class.path")
+                    + " " + Daten.EFADIREKT_MAINCLASS + de.nmichael.efa.boathouse.Main.STARTARGS);
+            String[] cmdargs = restartargs.split(" ");
+            String[] cmd = new String[cmdargs.length + 1];
+            cmd[0] = System.getProperty("java.home") + Daten.fileSep + "bin" + Daten.fileSep + "java";
+            for (int i=0; i<cmdargs.length; i++) {
+                cmd[i+1] = cmdargs[i];
+            }
+            Logger.log(Logger.INFO, Logger.MSG_EVT_EFARESTART,
+                    International.getMessage("Neustart mit Kommando: {cmd}", EfaUtil.arr2string(cmd)));
+            try {
+                Runtime.getRuntime().exec(cmd);
+            } catch (Exception ee) {
+                Logger.log(Logger.ERROR, Logger.MSG_ERR_EFARESTARTEXEC_FAILED,
+                        LogString.cantExecCommand(EfaUtil.arr2string(cmd), International.getString("Kommando")));
+            }
+        }
+		
 		if (program != null) {
 			program.exit(exitCode);
 		} else {

--- a/de/nmichael/efa/Daten.java
+++ b/de/nmichael/efa/Daten.java
@@ -79,7 +79,7 @@ public class Daten {
 																	// auch Zusätze wie "alpha" o.ä. enthalten)
 	public final static String VERSIONID = "2.4.1_#17"; // VersionsID: Format: "X.Y.Z_MM"; final-Version z.B. 1.4.0_00;
 														// beta-Version z.B. 1.4.0_#1  //# is not good, is used in efa.data.Waters 
-	public final static String VERSIONRELEASEDATE = "08.06.2025"; // Release Date: TT.MM.JJJJ
+	public final static String VERSIONRELEASEDATE = "09.06.2025"; // Release Date: TT.MM.JJJJ
 	public final static String MAJORVERSION = "2";
 	public final static String PROGRAMMID = "EFA.240"; // Versions-ID für Wettbewerbsmeldungen
 	public final static String PROGRAMMID_DRV = "EFADRV.241"; // Versions-ID für Wettbewerbsmeldungen

--- a/de/nmichael/efa/Daten.java
+++ b/de/nmichael/efa/Daten.java
@@ -379,21 +379,6 @@ public class Daten {
 			}
 		}
 
-		if (exitCode != 0) {
-			if (exitCode == Daten.HALT_SHELLRESTART || exitCode == Daten.HALT_JAVARESTART) {
-				Logger.log(Logger.INFO, Logger.MSG_CORE_HALT,
-						International.getString("PROGRAMMENDE") + " (Exit Code " + exitCode + ")");
-			} else {
-				if (Daten.applID != Daten.APPL_CLI) {
-					Logger.log(Logger.INFO, Logger.MSG_CORE_HALT, getCurrentStack());
-				}
-				Logger.log(Logger.ERROR, Logger.MSG_CORE_HALT,
-						International.getString("PROGRAMMENDE") + " (Error Code " + exitCode + ")");
-			}
-		} else {
-			Logger.log(Logger.INFO, Logger.MSG_CORE_HALT, International.getString("PROGRAMMENDE"));
-		}
-		
 		// On Windows systems, efa relies on java restart. So we need to take care of the java-based restart
 		// AFTER running the haltProgram code. Otherwise, the new efa instance may be run faster than the current one has shut down.
 		if (exitCode == Daten.HALT_JAVARESTART ) {
@@ -414,7 +399,24 @@ public class Daten {
                 Logger.log(Logger.ERROR, Logger.MSG_ERR_EFARESTARTEXEC_FAILED,
                         LogString.cantExecCommand(EfaUtil.arr2string(cmd), International.getString("Kommando")));
             }
-        }
+        }		
+		
+		// PROGRAMMENDE log entry must be the last to be shown on efa shutdown/restart,
+		// as efa looks for this line on startup and will state efa has not been shut down correctly if it is missing.
+		if (exitCode != 0) {
+			if (exitCode == Daten.HALT_SHELLRESTART || exitCode == Daten.HALT_JAVARESTART) {
+				Logger.log(Logger.INFO, Logger.MSG_CORE_HALT,
+						International.getString("PROGRAMMENDE") + " (Exit Code " + exitCode + ")");
+			} else {
+				if (Daten.applID != Daten.APPL_CLI) {
+					Logger.log(Logger.INFO, Logger.MSG_CORE_HALT, getCurrentStack());
+				}
+				Logger.log(Logger.ERROR, Logger.MSG_CORE_HALT,
+						International.getString("PROGRAMMENDE") + " (Error Code " + exitCode + ")");
+			}
+		} else {
+			Logger.log(Logger.INFO, Logger.MSG_CORE_HALT, International.getString("PROGRAMMENDE"));
+		}
 		
 		if (program != null) {
 			program.exit(exitCode);

--- a/de/nmichael/efa/Program.java
+++ b/de/nmichael/efa/Program.java
@@ -208,30 +208,11 @@ public class Program {
     }
 
     public int restart() {
-        int exitCode;
         if (Daten.javaRestart) {
-            exitCode = Daten.HALT_JAVARESTART;
-            String restartargs = (Daten.efa_java_arguments != null ? Daten.efa_java_arguments
-                    : "-cp " + System.getProperty("java.class.path")
-                    + " " + Daten.EFADIREKT_MAINCLASS + de.nmichael.efa.boathouse.Main.STARTARGS);
-            String[] cmdargs = restartargs.split(" ");
-            String[] cmd = new String[cmdargs.length + 1];
-            cmd[0] = System.getProperty("java.home") + Daten.fileSep + "bin" + Daten.fileSep + "java";
-            for (int i=0; i<cmdargs.length; i++) {
-                cmd[i+1] = cmdargs[i];
-            }
-            Logger.log(Logger.INFO, Logger.MSG_EVT_EFARESTART,
-                    International.getMessage("Neustart mit Kommando: {cmd}", EfaUtil.arr2string(cmd)));
-            try {
-                Runtime.getRuntime().exec(cmd);
-            } catch (Exception ee) {
-                Logger.log(Logger.ERROR, Logger.MSG_ERR_EFARESTARTEXEC_FAILED,
-                        LogString.cantExecCommand(EfaUtil.arr2string(cmd), International.getString("Kommando")));
-            }
+            return Daten.HALT_JAVARESTART;
         } else {
-            exitCode = Daten.HALT_SHELLRESTART;
+            return Daten.HALT_SHELLRESTART;
         }
-        return exitCode;
     }
 
     public void exit(int exitCode) {

--- a/eou/eou.xml
+++ b/eou/eou.xml
@@ -12,13 +12,15 @@
         <Changes lang="de">
         	<ChangeItem>Neu: update runEfa.bat/.sh - 192MB RAM statt 160MB für efa JavaVM, wegen Speicher-Mehrbedarf für efaCloud.</ChangeItem>
 			<ChangeItem>Neu: Boote, die in anderen Logbüchern 'auf Fahrt' sind, können als 'nicht verfügbare Boote' angezeigt werden.</ChangeItem>
-        	<ChangeItem>Bugfix: Auswahlliste für Personen wird aktualisiert, wenn bei Neuanlage einer Fahrt das Boot oder die Bootsvariante geändert wird.</ChangeItem>        	
+        	<ChangeItem>Bugfix: Auswahlliste für Personen wird aktualisiert, wenn bei Neuanlage einer Fahrt das Boot oder die Bootsvariante geändert wird.</ChangeItem>
+        	<ChangeItem>Bugfix: Efa-Neustart unter Windows funktioniert zuverlässiger, es gibt keine Meldungen mehr 'efa läuft bereits im Hintergrund'.</ChangeItem>        	
         	<ChangeItem>Bugfix: efaCloud: Ecrid Index Handling verbessert: keine Probleme mehr nach dem Aufsetzen neuer efaCloud Systeme</ChangeItem>
         </Changes>
         <Changes lang="en">
         	<ChangeItem>New: update runEfa.bat/.sh - 192MB RAM instead of 160MB for efa JavaVM, due to higher demands for efaCloud.</ChangeItem>
 			<ChangeItem>New: Boats which are 'on the water' in other logbooks, can be shown as 'not available boats'</ChangeItem>
         	<ChangeItem>Bugfix: When changing the boat or boatvariant while creating a new session, the autocomplete list for persons get a refresh.</ChangeItem>        	
+        	<ChangeItem>Bugfix: A restart of efa works better on Windows(r) systems. There are no longer messages like 'efa is already running in background'.</ChangeItem>        	
         	<ChangeItem>Bugfix: efaCloud: Ecrid index handling optimized: no more issues when setting up new efaCloud systems.</ChangeItem>
         </Changes>	
 	</Version>


### PR DESCRIPTION
Bug description see https://github.com/nicmichael/efa/issues/262

On windows systems, efa is restarted by starting a new efa instance by executing a java command.
This command is now run AFTER the shutdown sequence of efa has finished, instead of running it in parallel.