### PR TITLE
Fixed Issues EFA#136 and EFA#137

### DIFF
--- a/de/nmichael/efa/Daten.java
+++ b/de/nmichael/efa/Daten.java
@@ -80,7 +80,7 @@ public class Daten {
 
 	public final static String VERSIONID = "2.5.0"; // VersionsID: Format: "X.Y.Z_MM"; final-Version z.B. 1.4.0_00;
 														// beta-Version z.B. 1.4.0_#1  //# is not good, is used in efa.data.Waters 
-	public final static String VERSIONRELEASEDATE = "10.02.2026"; // Release Date: TT.MM.JJJJ
+	public final static String VERSIONRELEASEDATE = "14.02.2026"; // Release Date: TT.MM.JJJJ
 	public final static String MAJORVERSION = "2";
 	public final static String PROGRAMMID = "EFA.250"; // Versions-ID für Wettbewerbsmeldungen
 	public final static String PROGRAMMID_DRV = "EFADRV.250"; // Versions-ID für Wettbewerbsmeldungen

--- a/de/nmichael/efa/data/LogbookRecord.java
+++ b/de/nmichael/efa/data/LogbookRecord.java
@@ -133,6 +133,11 @@ public class LogbookRecord extends DataRecord {
     public static final int CREW_MAX = 24;
     public static final String WATERS_SEPARATORS = ",;+";
 
+    public static final String EMPTY="";
+    //This is the name of the logbook the logbookrecord got created in.
+    //
+    private String logbookName = EMPTY;
+    
     // =========================================================================
     // Temporary Fields for Evaluation (not stored in the persistent record!)
     // =========================================================================
@@ -234,12 +239,23 @@ public class LogbookRecord extends DataRecord {
 
     public LogbookRecord(Logbook logbook, MetaData metaData) {
         super(logbook, metaData);
+        this.logbookName = logbook.getName();
     }
 
     public DataRecord createDataRecord() { // used for cloning
-        return getPersistence().createNewRecord();
+        //we do not need to take care for setting logbookname property
+    	//as this function automatically calls the constructor of logbookrecord.
+    	return getPersistence().createNewRecord();
     }
 
+    /**
+     * Get the name of the logbook that has been set while constructing this logbookrecord.
+     * @return
+     */
+    public String getLogbookName() {
+    	return logbookName;
+    }
+    
     public DataKey getKey() {
         return new DataKey<DataTypeIntString,String,String>(getEntryId(),null,null);
     }

--- a/de/nmichael/efa/data/efacloud/SynchControl.java
+++ b/de/nmichael/efa/data/efacloud/SynchControl.java
@@ -39,7 +39,7 @@ class SynchControl {
     static final long synch_upload_look_back_ms = 15 * 24 * 3600000L; // period in past to check for upload
     static final long surely_newer_after_ms = 60000L; // one-minute time difference accepted for timestamps server <-> client
     
-    private static final int SYNCHERRORS_LOG_MAX_SIZE = 200000; //200 kb. 
+    private static final int SYNCHERRORS_LOG_MAX_SIZE = 10 * 1024 * 1024; // During upload sync only last 200kb are transferred, see TextResource
     private static final String FILENAME_PREVIOUS_SUFFIX = ".previous.log";
 
     long lastSynchStartedMillis;
@@ -96,20 +96,22 @@ class SynchControl {
         File synchErrorsFile = new File(path);
         
         Boolean appendLine=true;
-        
-        //synchErrors.log rotation: if >5 Mb, delete old synchErrors.previous.log file and rename synchErrors.log to synchErrors.log.previous.log
-        if (synchErrorsFile.length() > SYNCHERRORS_LOG_MAX_SIZE) {
-        	File oldPreviousLogfile=new File(path + FILENAME_PREVIOUS_SUFFIX);
-        	
-        	// rotate existing efacloud.log to efacloud.log.previous and delete the existing file if necessary.
-        	if ((oldPreviousLogfile.exists() && oldPreviousLogfile.delete()) 
-        			|| (!oldPreviousLogfile.exists())) {
-        		if (synchErrorsFile.renameTo(new File(path + FILENAME_PREVIOUS_SUFFIX))) {
-        			appendLine=false;
-        		}
-        	}
+        if (isError) {
+        	//log rotation only if we write to synchError.log
+	        //synchErrors.log rotation: if >5 Mb, delete old synchErrors.previous.log file and rename synchErrors.log to synchErrors.log.previous.log
+	        if (synchErrorsFile.length() > SYNCHERRORS_LOG_MAX_SIZE) {
+	        	File oldPreviousLogfile=new File(path + FILENAME_PREVIOUS_SUFFIX);
+	        	
+	        	// rotate existing efacloud.log to efacloud.log.previous and delete the existing file if necessary.
+	        	if ((oldPreviousLogfile.exists() && oldPreviousLogfile.delete()) 
+	        			|| (!oldPreviousLogfile.exists())) {
+	        		if (synchErrorsFile.renameTo(new File(path + FILENAME_PREVIOUS_SUFFIX))) {
+	        			appendLine=false;
+	        		}
+	        	}
+	        }
         }
-        
+        // write to logfile, either synchError or efacloud.log
         TextResource.writeContents(path, dateString, appendLine);
     }
 
@@ -154,13 +156,16 @@ class SynchControl {
     }
 
     /**
-     * In case an EntryId of a logbook entry is corrected, ensure that also the boat status is updated. Only by that
-     * update it is ensured the trip can be closed later.
+     * In case an EntryId of a logbook entry is corrected, ensure that also the boat status is updated. 
+     * Only by that update it is ensured the trip can be closed later.
+     * 
+     * The boat status only gets updated if the boat status points to the same logbook as the logbookrecord
+     * which got a new entryID.
      *
      * @param boatId The UUID of the boat in the boat status
      * @param fixedEntryNo   new EntryId for this boat status
      */
-    protected void adjustBoatStatus(UUID boatId, int fixedEntryNo) {
+    protected void adjustBoatStatus(UUID boatId, int oldEntryNo, String oldLogbookName, int fixedEntryNo) {
         EfaCloudStorage boatstatus = Daten.tableBuilder.getPersistence("efa2boatstatus");
         DataKeyIterator it;
         try {
@@ -170,12 +175,17 @@ class SynchControl {
                 BoatStatusRecord bsr = (BoatStatusRecord) boatstatus.get(boatstatuskey);
                 if (bsr.getBoatId() != null) {
                     if (bsr.getBoatId().compareTo(boatId) == 0) {
-                        bsr.setEntryNo(new DataTypeIntString("" + fixedEntryNo));
-                        long globalLock = boatstatus.acquireGlobalLock();
-                        boatstatus.update(bsr, globalLock);
-                        boatstatus.releaseGlobalLock(globalLock);
-                        logSynchMessage(International.getString("Korrigiere EntryNo in BoatStatus"), "efa2boatstatus",
-                                boatstatuskey, false);
+                    	//Only update the boatstatusrecord if it points to the same logbook as 
+                    	//the record which got a new entryID.
+                    	if (bsr.getLogbook().equalsIgnoreCase(oldLogbookName)) {
+	                        bsr.setEntryNo(new DataTypeIntString("" + fixedEntryNo));
+	                        long globalLock = boatstatus.acquireGlobalLock();
+	                        boatstatus.update(bsr, globalLock);
+	                        boatstatus.releaseGlobalLock(globalLock);
+	                        logSynchMessage(International.getString("Korrigiere EntryNo in BoatStatus"), "efa2boatstatus",
+	                                boatstatuskey, false);
+                    	}
+                    		
                     }
                 }
                 boatstatuskey = it.getNext();
@@ -450,16 +460,20 @@ class SynchControl {
                             if (localLastModified > LastModifiedLimit)
                                 localRecordsToInsertAtServer.add(localRecord);
                         } else if (localLastModified > serverRecord.getLastModified()) {
-                            String preUpdateRecordsCompareResult = ""; // removed August 2024: preUpdateRecordsCompare(localRecord, serverRecord, tx.tablename);
-                            if (!preUpdateRecordsCompareResult.isEmpty())
-                                localRecordsToUpdateAtServer.add(localRecord);
-                            else {
+                        	// removed August 2024: String preUpdateRecordsCompare(localRecord, serverRecord, tx.tablename);
+                        	/* String preUpdateRecordsCompareResult = "";  
+                             * if (!preUpdateRecordsCompareResult.isEmpty()) {
+                             *   localRecordsToUpdateAtServer.add(localRecord);
+                             * } else { 
+                             */ 
+                        		// just get a comparison of the records so that we can log them and the user can actually have a hint what has changed.
+                            	String preUpdateRecordsCompareResult = preUpdateRecordsCompare(localRecord, serverRecord, tx.tablename);
                                 logSynchMessage(International.getMessage(
                                         "Update-Konflikt bei Datensatz in der {type}-Synchronisation. Unterschiedlich sind: {fields}",
                                         "Upload", preUpdateRecordsCompareResult) +
                                         " " + International.getString("Bitte bereinige den Datensatz manuell."), tx.tablename,
                                         toCheck, false);
-                            }
+                            //}
                         }
                         toCheck = it.getNext();
                     }
@@ -497,6 +511,51 @@ class SynchControl {
                     "Transaktionen für Synchronisation vollständig angestoßen. Warte auf Fertigstellung."), "",
                     null, false);
         }
+    }
+    
+    /**
+     * Compares two records and points out which fields differ from another.
+     *
+     * @param dr1 DataRecord one to compare
+     * @param dr2 DataRecord two to compare
+     * @param tablename the table name to look up how many fields may be different.
+     * @return empty String, if the records are of the same type and differ in only a tolerable amount of data fields
+     */
+    private String preUpdateRecordsCompare(DataRecord dr1, DataRecord dr2, String tablename) {
+        if (!efaCloudRolleBths && !isBoathouseApp)
+            return "";
+        if ((dr1 == null) || (dr2 == null) || (dr1.getClass() != dr2.getClass()))
+            return "type mismatch";
+        // if archiving is executed or an archived record is restored, do not check for mismatches
+        // because the archived record stub will have all fields changed.
+
+        int diff = 0;
+        StringBuilder fieldList = new StringBuilder();
+        for (String field : dr1.getFields()) {
+            if (!field.equalsIgnoreCase("ChangeCount")
+                    && !field.equalsIgnoreCase("LastModified")
+                    && !field.equalsIgnoreCase("LastModification")) {
+            	
+            	String f1Value = dr1.getAsString(field);
+            	String f2Value = dr2.getAsString(field);
+            	
+                if (f1Value == null) {
+                    if (f2Value != null) {
+                        fieldList.append(field).append("(null").append("/").append(f2Value).append(")").append(", ");
+                        diff ++;
+                    }
+                } else if (f2Value == null) {
+                    fieldList.append(field).append("(").append(f1Value).append("/null)").append(", ");
+                    diff++;
+                    // Use String comparison as the compareTo() implementation throws to many different exceptions.
+                } else if (!dr1.getAsString(field).equalsIgnoreCase(dr2.getAsString(field))) {
+                    fieldList.append(field).append("(").append(f1Value).append("/").append(f2Value).append(", ");
+                    diff++;
+                }
+            }
+        }
+
+        return fieldList.toString();
     }
 
 }

--- a/de/nmichael/efa/data/efacloud/TextResource.java
+++ b/de/nmichael/efa/data/efacloud/TextResource.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
  */
 public class TextResource {
 
+    private final static int TAIL_SIZE = 200 * 1024; // 200 KB
+    
     /**
      * <p>
      * Fetch the entire contents of a text file, and return it in a String. This style of implementation does not throw
@@ -74,13 +76,112 @@ public class TextResource {
                 contents.append("\n");
             }
         } catch (IOException ex) {
-            return null;
+            return "";
         }
         if (contents.length() == 0)
             return "";
         // remove last "\n" character.
         return contents.substring(0, contents.length() - 1);
     }
+    
+    /**
+     * <p>
+     * Fetch the last TAIL_SIZE bytes of contents of a text file, and return it in a String. 
+     * This style of implementation does not throw exceptions to the caller, 
+     * but returns a null String, when hitting an IOException.
+     * 
+     * This method is intended to be used for log file uploads to efaCloud,
+     * so that big logfiles do not affect upload size or upload times.
+     * 
+     * </p>
+     *
+     * <pre>
+     * Charset     Description
+     * US-ASCII    Seven-bit ASCII, a.k.a. ISO646-US, a.k.a. the Basic Latin block of
+     *             the Unicode character set
+     * ISO-8859-1  ISO Latin Alphabet No. 1, a.k.a. ISO-LATIN-1
+     * UTF-8       Eight-bit UCS Transformation Format
+     * UTF-16BE    Sixteen-bit UCS Transformation Format, big-endian byte order
+     * UTF-16LE    Sixteen-bit UCS Transformation Format, little-endian byte order
+     * UTF-16      Sixteen-bit UCS Transformation Format, byte order identified by
+     * an optional byte-order mark
+     *
+     * <pre>
+     *
+     * @param aFile File to be read
+     * @param charSetName character set to be used. Set null for default character set
+     * @return empty string, if not successful.
+     */    
+    public static String getTailContents(File file, String charSetName) {
+        if (file == null || !file.exists() || !file.isFile() || !file.canRead()) {
+            return "";
+        }
+
+        Charset charset;
+
+        try {
+            if (charSetName == null || charSetName.trim().isEmpty()) {
+                charset = Charset.defaultCharset();
+            } else {
+                charset = Charset.forName(charSetName);
+            }
+        } catch (Exception e) {
+            return ""; // invalid charset
+        }
+
+        long fileLength = file.length();
+        // just get the last TAIL_SIZE bytes of the file.
+        long startPos = Math.max(0, fileLength - TAIL_SIZE);
+
+        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+
+            // Jump to start position
+            raf.seek(startPos);
+
+            // Supposed logfiles - we don't want to start in the middle of a line,
+            // but directly after a newline. 
+            if (startPos > 0) {
+                int b;
+                while ((b = raf.read()) != -1) {
+                    if (b == '\n') {
+                        break;
+                    }
+                }
+            }
+
+            long extractStart = raf.getFilePointer();
+
+            // if file <TAIL_SIZE or no newline has been found
+            if (extractStart < 0 || extractStart > fileLength) {
+                extractStart = 0;
+                raf.seek(0);
+            }
+
+            // Now use the standard reader to read the log file into a single string
+            try (InputStreamReader isr = new InputStreamReader(new FileInputStream(raf.getFD()), charset);
+                 BufferedReader br = new BufferedReader(isr)) {
+
+                StringBuilder sb = new StringBuilder(64 * 1024);
+                String line;
+
+                while ((line = br.readLine()) != null) {
+                    sb.append(line).append('\n');
+                }
+
+                if (sb.length() == 0) {
+                    return "";
+                }
+
+                // remove last \n 
+                sb.setLength(sb.length() - 1);
+                return sb.toString();
+            }
+
+        } catch (IOException e) {
+            return "";
+        }
+    }
+
 
     /**
      * <p>

--- a/de/nmichael/efa/data/efacloud/Transaction.java
+++ b/de/nmichael/efa/data/efacloud/Transaction.java
@@ -10,18 +10,19 @@
  */
 package de.nmichael.efa.data.efacloud;
 
-import de.nmichael.efa.Daten;
-import de.nmichael.efa.data.storage.EfaCloudStorage;
-
 import java.io.File;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 // import java.nio.charset.StandardCharsets;  Java 8 only
 // import java.util.Base64;  Java 8 only
 
 import java.util.HashMap;
-import java.util.ArrayList;
 import java.util.Vector;
+
+import de.nmichael.efa.Daten;
+import de.nmichael.efa.data.storage.EfaCloudStorage;
 
 /**
  * A container class for data modifications passed to the efaClod Server.
@@ -130,7 +131,8 @@ public class Transaction {
         for (Transaction tx : txs) {
             tx.appendTxPostString(txContainer);
             txq.logApiMessage("tx" + tx.ID + ", " + tx.type + " [" + tx.tablename + "]: Transaction sent. Record length: "
-                    + ((tx.record == null) ? "null" : "" + tx.record.length), 0);
+                        + ((tx.record == null) ? "null" : "" + tx.record.length)
+                        + (txq.isExtendedDebug ? "   -   " + Arrays.toString(tx.record) : "" ), 0);
             txContainer.append(MESSAGE_SEPARATOR_STRING);
         }
         String txContainerStr = txContainer.toString();

--- a/de/nmichael/efa/data/efacloud/TxRequestQueue.java
+++ b/de/nmichael/efa/data/efacloud/TxRequestQueue.java
@@ -101,7 +101,7 @@ public class TxRequestQueue implements TaskManager.RequestDispatcherIF {
     private static final int DONE_QUEUE_MAX_TXS = 50;
     private static final int DROPPED_QUEUE_MAX_TXS = 50;
     
-    private static final int EFACLOUD_LOG_MAX_SIZE = 200000; //200 kb. 
+    private static final int EFACLOUD_LOG_MAX_SIZE = 10 * 1024 *1024; // 25 MBytes, during upload sync only last 200kb are transferred.
     private static final String FILENAME_PREVIOUS_SUFFIX = ".previous.log";    
 
     // Transaction queue indices and names.
@@ -233,6 +233,8 @@ public class TxRequestQueue implements TaskManager.RequestDispatcherIF {
     public String adminSessionMessage;
     private Container efaGUIroot;
     private long lastStatsUpload = 0L;
+    
+    public Boolean isExtendedDebug = true; //intentionally set to true so that the sync log provides better data traceability.
 
     /**
      * Get a new transaction ID and increment the counter.
@@ -607,10 +609,10 @@ public class TxRequestQueue implements TaskManager.RequestDispatcherIF {
                     fa.putContent(fa.getInstance(cfgFname, false), cfgFile);
                 }
                 // add the log and synchronisation errors file
-                String errorsFile = TextResource.getContents(new File(synchErrorFilePath), "UTF-8");
+                String errorsFile = TextResource.getTailContents(new File(synchErrorFilePath), "UTF-8");
                 if (TxRequestQueue.logs_to_return >= 1)
                     fa.putContent(fa.getInstance("synchErrors.log", false), errorsFile);
-                String logFile = TextResource.getContents(new File(logFilePath), "UTF-8");
+                String logFile = TextResource.getTailContents(new File(logFilePath), "UTF-8");
                 if (TxRequestQueue.logs_to_return >= 2)
                     fa.putContent(fa.getInstance("efacloud.log", false), logFile);
                 // Java8: return Base64.getEncoder().encodeToString(fa.getZipAsBytes());

--- a/de/nmichael/efa/data/efacloud/TxResponseHandler.java
+++ b/de/nmichael/efa/data/efacloud/TxResponseHandler.java
@@ -48,9 +48,10 @@ public class TxResponseHandler {
             transactionString += ". " + ((tx.getResultMessage().length() > 100) ?
                     tx.getResultMessage().substring(0, 100) + " ..." : tx.getResultMessage());
         String dateString = format.format(new Date()) + " INFO tx" + tx.ID + ", ";
-        TextResource
-                .writeContents(TxRequestQueue.logFilePath, dateString + transactionString,
-                        true);
+        if (txq.isExtendedDebug && (tx.type.typeString.equals("insert")||tx.type.typeString.equals("update")||tx.type.typeString.equals("delete"))) {
+        	transactionString += "   -   " + tx.getResultMessage();
+        }
+        TextResource.writeContents(TxRequestQueue.logFilePath, dateString + transactionString, true);
     }
 
     /**
@@ -326,9 +327,13 @@ public class TxResponseHandler {
                         efaCloudStorage.modifyLocalRecord(updated, false, true, false);
                         // check and update the boat status record, if the current trip is open
                         // you will have to use a new lock, because the old one uses the wrong table
-                        if (tx.tablename.equals(Logbook.DATATYPE) && (((LogbookRecord) current).getSessionIsOpen()))
-                            txq.synchControl.adjustBoatStatus(((LogbookRecord) current).getBoatId(),
-                                    ((LogbookRecord) updated).getEntryId().intValue());
+                        if (tx.tablename.equals(Logbook.DATATYPE) && (((LogbookRecord) current).getSessionIsOpen())) {
+                            txq.synchControl.adjustBoatStatus(
+                            		((LogbookRecord) current).getBoatId(),
+                            		((LogbookRecord) current).getEntryId().intValue(),
+                            		((LogbookRecord) current).getLogbookName(),
+                            		((LogbookRecord) updated).getEntryId().intValue());
+                        }
                     } catch (EfaException e) {
                         // if immediate update does not work, synchronisation will care for it
                     }

--- a/eou/eou.xml
+++ b/eou/eou.xml
@@ -2,7 +2,7 @@
 <efaOnlineUpdate>
     <Version>
         <VersionID>2.5.0</VersionID>
-        <ReleaseDate>10.02.2025</ReleaseDate>
+        <ReleaseDate>14.02.2025</ReleaseDate>
         <DownloadUrl>TODO</DownloadUrl>
         <DownloadSize>TODO</DownloadSize>
      	<MinimumJavaVersion>1.8</MinimumJavaVersion>
@@ -10,10 +10,16 @@
         <ShowNotice lang="de">Wenn efaCloud eingesetzt wird, muss der Server mindestens Version 2.3.3 unterstützen. EfaCloud 2.4.0_12 und höher werden empfohlen.</ShowNotice>
         <ShowNotice lang="en">If you use efaCloud, make sure your server at least supports efaCloud Version 2.3.3. It is recommended to upgrade to EfaCloud 2.4.0_12 or above.</ShowNotice>
         <Changes lang="de">
-            <ChangeItem>Neu: Veröffentlichung efa 2.5.0 auf unveränderter Basis von efa 2.5.0#21</ChangeItem>         
+            <ChangeItem>Neu: Veröffentlichung efa 2.5.0 auf Basis von efa 2.5.0#21</ChangeItem>         
+            <ChangeItem>Neu: efaCloud: Lokale efaCloud-Log-Dateien werden bis zu 10 MByte groß; bei Upload-Sync werden nur die letzten 200kb der efaCloud-Log-Dateien hochgeladen.</ChangeItem>
+            <ChangeItem>Neu: efaCloud: Erweitertes Logging in efaCloud.log zur besseren Nachvollziehbarkeit in Bezug auf die transferierten Daten.</ChangeItem>
+            <ChangeItem>Bugfix: efaCloud: Aktualisierung von Boatstatusrecord bei Veränderung der Fahrtnummer im Fahrtenbuch erfolgt nur noch, wenn sich beide auf das gleiche Fahrtenbuch beziehen.</ChangeItem>
         </Changes>
         <Changes lang="en">
-            <ChangeItem>Neu: Publishing efa 2.5.0 based on unmodified efa 2.5.0#21</ChangeItem>          
+            <ChangeItem>Neu: Publishing efa 2.5.0 based on efa 2.5.0#21</ChangeItem>
+			<ChangeItem>New: efaCloud: Local efaCloud log files can be up to 10 MB in size; during upload sync, only the last 200 KB of the efaCloud log files are uploaded.</ChangeItem>
+			<ChangeItem>New: efaCloud: Enhanced logging in efaCloud.log for improved traceability of transferred data.</ChangeItem>
+			<ChangeItem>Bugfix: efaCloud: Boat status records are now only updated when the trip number in the logbook changes if both entries refer to the same logbook.</ChangeItem>            
         </Changes>
     </Version>
     <Version>


### PR DESCRIPTION
* New: efaCloud: Local efaCloud log files can be up to 10 MB in size; during upload sync, only the last 200 KB of the efaCloud log files are up.loaded.
* New: efaCloud: Enhanced logging in efaCloud.log for improved traceability of transferred data.
* Bugfix: efaCloud: Boat status records are now only updated when the trip number in the logbook changes if both entries refer to the same logbook.