### PR TITLE
Update Widgets: Better scrolling, retry on loading weather data.

### DIFF
--- a/de/nmichael/efa/Daten.java
+++ b/de/nmichael/efa/Daten.java
@@ -80,7 +80,7 @@ public class Daten {
 
 	public final static String VERSIONID = "2.5.1_#9"; // VersionsID: Format: "X.Y.Z_MM"; final-Version z.B. 1.4.0_00;
 														// beta-Version z.B. 1.4.0_#1  //# is not good, is used in efa.data.Waters 
-	public final static String VERSIONRELEASEDATE = "17.02.2026"; // Release Date: TT.MM.JJJJ
+	public final static String VERSIONRELEASEDATE = "19.02.2026"; // Release Date: TT.MM.JJJJ
 	public final static String MAJORVERSION = "2";
 	public final static String PROGRAMMID = "EFA.251"; // Versions-ID für Wettbewerbsmeldungen
 	public final static String PROGRAMMID_DRV = "EFADRV.251"; // Versions-ID für Wettbewerbsmeldungen

--- a/de/nmichael/efa/core/config/EfaConfig.java
+++ b/de/nmichael/efa/core/config/EfaConfig.java
@@ -342,11 +342,6 @@ public class EfaConfig extends StorageObject implements IItemFactory {
 	private ItemTypeColor efaGuiToolTipHeaderBackground; 
 	private ItemTypeColor efaGuiToolTipHeaderForeground;
 	
-	private ItemTypeColor efaGuiErrorBackground; 
-	private ItemTypeColor efaGuiErrorForeground;
-	private ItemTypeColor efaGuiErrorHeaderBackground; 
-	private ItemTypeColor efaGuiErrorHeaderForeground;
-	
 	private ItemTypeStringList efaDirekt_bnrMsgToAdminDefaultRecipient;
 	private ItemTypeBoolean efaDirekt_bnrError_admin;
 	private ItemTypeBoolean efaDirekt_bnrError_bootswart;
@@ -1852,7 +1847,7 @@ public class EfaConfig extends StorageObject implements IItemFactory {
 			crontab.setAppendPositionToEachElement(false);
 			crontab.setShortDescription("Task");
 			crontab.setRepeatTitle(true);
-			crontab.setShowUpDownButtons(false);
+			crontab.setShowUpDownButtons(true);
 
 			// ============================= DATA ACCESS =============================
 			addParameter(dataPreModifyRecordCallbackEnabled = new ItemTypeBoolean("DataPreModifyRecordCallbackEnabled",
@@ -3172,26 +3167,6 @@ public class EfaConfig extends StorageObject implements IItemFactory {
 		Color myColor = efaGuiToolTipHeaderForeground.getColor();
 		return (myColor != null ? myColor : standardToolTipHeaderForegroundColor);
 	}
-
-	public Color getErrorBackgroundColor() {
-		Color myColor = efaGuiErrorBackground.getColor();
-		return (myColor != null ? myColor : standardErrorBackgroundColor);
-	}
-
-	public Color getErrorForegroundColor() {
-		Color myColor = efaGuiErrorForeground.getColor();
-		return (myColor != null ? myColor : standardErrorForegroundColor);
-	}
-
-	public Color getErrorHeaderBackgroundColor() {
-		Color myColor = efaGuiErrorHeaderBackground.getColor();
-		return (myColor != null ? myColor : standardErrorHeaderBackgroundColor);
-	}
-
-	public Color getErrorHeaderForegroundColor() {
-		Color myColor = efaGuiErrorHeaderForeground.getColor();
-		return (myColor != null ? myColor : standardErrorHeaderForegroundColor);
-	}	
 	
 	public Boolean getHeaderUseHighlightColor() {
 		return efaHeaderUseHighlightColor.getValue();

--- a/de/nmichael/efa/core/items/ItemTypeCronEntry.java
+++ b/de/nmichael/efa/core/items/ItemTypeCronEntry.java
@@ -10,9 +10,6 @@
 
 package de.nmichael.efa.core.items;
 
-import de.nmichael.efa.util.Dialog;
-import de.nmichael.efa.util.EfaUtil;
-import de.nmichael.efa.util.International;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
@@ -25,10 +22,15 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.StringTokenizer;
+
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+
+import de.nmichael.efa.util.Dialog;
+import de.nmichael.efa.util.EfaUtil;
+import de.nmichael.efa.util.International;
 
 public class ItemTypeCronEntry extends ItemTypeLabelValue {
 
@@ -232,8 +234,8 @@ public class ItemTypeCronEntry extends ItemTypeLabelValue {
                 GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 2), 0, 0));
         fFrequency.setForeground(Color.blue);
         Dimension dim = p.getPreferredSize();
-        p.validate();
-        setFieldSize(Math.min(dim.width, 670), Math.min(dim.height, 7*24));
+        p.revalidate();
+        setFieldSize(Math.min(dim.width, 500), Math.min(dim.height, 7*23));
         return p;
     }
 

--- a/de/nmichael/efa/core/items/ItemTypeItemList.java
+++ b/de/nmichael/efa/core/items/ItemTypeItemList.java
@@ -620,6 +620,12 @@ public class ItemTypeItemList extends ItemType {
             ((BaseDialog)dlg).updateGui();
         }
         
+        try {
+        	lastItemFocus = ((IItemType[])items.get(idx))[0];
+        } catch (Exception e1) {
+        	Logger.logdebug(e1);
+        	lastItemFocus = null;
+        } 
         if (lastItemFocus != null) {
         	lastItemFocus.requestFocus();
         }   

--- a/de/nmichael/efa/core/items/ItemTypeItemList.java
+++ b/de/nmichael/efa/core/items/ItemTypeItemList.java
@@ -36,6 +36,7 @@ import javax.swing.SwingConstants;
 import de.nmichael.efa.Daten;
 import de.nmichael.efa.gui.BaseDialog;
 import de.nmichael.efa.gui.BaseFrame;
+import de.nmichael.efa.gui.EfaGuiUtils;
 import de.nmichael.efa.gui.ImagesAndIcons;
 import de.nmichael.efa.gui.util.RoundedBorder;
 import de.nmichael.efa.gui.util.RoundedLabel;
@@ -124,6 +125,7 @@ public class ItemTypeItemList extends ItemType {
     private JScrollPane scrollPane;
     private JLabel titlelabel;
     private JButton addButton;
+    private Hashtable<JButton,Integer> addButtons;
     private Hashtable<JButton,Integer> delButtons;
     private Hashtable<JButton,Integer> upButtons;
     private Hashtable<JButton,Integer> downButtons;
@@ -182,8 +184,21 @@ public class ItemTypeItemList extends ItemType {
         return copy;
     }
 
+    /**
+     * Add items at the end of the list.
+     * @param items Items to be added.
+     */
     public void addItems(IItemType[] items) {
-        int idx = this.items.size();
+    	addItems(items, this.items.size());
+    }
+    
+    /** 
+     * Add Items below an item on the list.
+     * @param items Items to be added.
+     * @param afterIndex
+     */
+    public void addItems(IItemType[] items, int afterIndex) {
+        int idxForName = this.items.size();
         lastItemFocus = null;
         for (IItemType item : items) {
         	// check if the subitem's name already consists of the prefixes of the CURRENT itemlist.
@@ -191,7 +206,7 @@ public class ItemTypeItemList extends ItemType {
         	// in the context of copyOf method.
         	String internalName = item.getName();
             if (!item.getName().startsWith(this.getName())){
-            	internalName = getName() + "_" + idx + "_" + item.getName();
+            	internalName = getName() + "_" + idxForName + "_" + item.getName();
             }
             itemNameMapping.put(internalName, item.getName());
             item.setName(internalName);
@@ -201,7 +216,11 @@ public class ItemTypeItemList extends ItemType {
                 }
             }
         }
-        this.items.add(items);
+        if (afterIndex==0 || afterIndex>idxForName) {
+        	this.items.add(items);
+        } else {
+        	this.items.add(afterIndex,items);
+        }
     }
 
     public void removeItems(int idx) {
@@ -293,7 +312,6 @@ public class ItemTypeItemList extends ItemType {
         // not used, everything done in displayOnGui(...)
     }
     
-    
     public int displayOnGui(Window dlg, JPanel panel, int x, int y) {
         this.dlg = dlg;
         
@@ -316,7 +334,7 @@ public class ItemTypeItemList extends ItemType {
         titlelabel.setOpaque(true);
         titlelabel.setFont(titlelabel.getFont().deriveFont(Font.BOLD));
         titlelabel.setText(" " + getDescription());
-    
+        
         // we use a roundedPanel as base element so that we can add the caption on the left,
         // and highlight the add button on the right with some prominent text "new" and an extra arrow icon.
         int curYPos = 0;
@@ -358,6 +376,7 @@ public class ItemTypeItemList extends ItemType {
         addButton.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(ActionEvent e) { addButtonHit(e); }
         });
+        EfaGuiUtils.enableAutoScrollOnFocus(addButton);
 
         panel.add(addButton, new GridBagConstraints(x+xForAddDelButtons, y, 2, 1, 0.0, 0.0,
                 GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(padYbefore, 2, padYafter, padXafter), 0, 0));
@@ -368,6 +387,7 @@ public class ItemTypeItemList extends ItemType {
             curYPos++;
         }        
         
+        addButtons = new Hashtable<JButton, Integer>();
         delButtons = new Hashtable<JButton,Integer>();
         upButtons = new Hashtable<JButton,Integer>();
         downButtons = new Hashtable<JButton,Integer>();
@@ -395,6 +415,16 @@ public class ItemTypeItemList extends ItemType {
             delButton.addActionListener(new java.awt.event.ActionListener() {
                 public void actionPerformed(ActionEvent e) { delButtonHit(e); }
             });
+            EfaGuiUtils.enableAutoScrollOnFocus(delButton);
+            
+            JButton addButtonAtItem = new JButton();
+            addButtonAtItem.setIcon(BaseFrame.getIcon("menu_plus.gif"));
+            addButtonAtItem.setMargin(new Insets(0,0,0,0));
+            Dialog.setPreferredSize(addButtonAtItem, 19, 19);
+            addButtonAtItem.addActionListener(new java.awt.event.ActionListener() {
+                public void actionPerformed(ActionEvent e) { addButtonAfterPositionHit(e); }
+            });
+            EfaGuiUtils.enableAutoScrollOnFocus(addButtonAtItem);
 
             JButton upButton =null;
             JButton downButton = null;
@@ -407,6 +437,8 @@ public class ItemTypeItemList extends ItemType {
                 upButton.addActionListener(new java.awt.event.ActionListener() {
                     public void actionPerformed(ActionEvent e) { upButtonHit(e); }
                 });
+                EfaGuiUtils.enableAutoScrollOnFocus(upButton);
+
                 downButton = new JButton();
                 downButton.setIcon(ImagesAndIcons.getIcon(ImagesAndIcons.ARROW_DOWN));
                 downButton.setMargin(new Insets(0,0,0,0));
@@ -414,6 +446,8 @@ public class ItemTypeItemList extends ItemType {
                 downButton.addActionListener(new java.awt.event.ActionListener() {
                     public void actionPerformed(ActionEvent e) { downButtonHit(e); }
                 });                
+                EfaGuiUtils.enableAutoScrollOnFocus(downButton);
+
                 /*
                  * [label] [upbutton][downbutton] [delete]
                  */
@@ -425,15 +459,19 @@ public class ItemTypeItemList extends ItemType {
 
 	            panel.add(delButton, new GridBagConstraints(x+xForAddDelButtons, y+curYPos, 1, 1, 0.0, 0.0,
 	                    GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets((label==null ? 0 : padYbetween), 2, (label==null ? 0 : padYbetween), 0), 0, 0));
+
+	            panel.add(addButtonAtItem, new GridBagConstraints(x+(xForAddDelButtons*2), y+curYPos, 1, 1, 0.0, 0.0,
+	                    GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets((label==null ? 0 : padYbetween), 2, (label==null ? 0 : padYbetween), 0), 0, 0));
 	            
-	            panel.add(upButton, new GridBagConstraints(x+xForAddDelButtons+xForAddDelButtons, y+curYPos, 1, 1, 0.0, 0.0,
+	            panel.add(upButton, new GridBagConstraints(x+(xForAddDelButtons*3), y+curYPos, 1, 1, 0.0, 0.0,
 	                    GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets((label==null ? 0 : padYbetween), 2, (label==null ? 0 : padYbetween), 0), 0, 0));
 
-	            panel.add(downButton, new GridBagConstraints(x+xForAddDelButtons+xForAddDelButtons+xForAddDelButtons, y+curYPos, 1, 1, 0.0, 0.0,
+	            panel.add(downButton, new GridBagConstraints(x+(xForAddDelButtons*4), y+curYPos, 1, 1, 0.0, 0.0,
 	                    GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets((label==null ? 0 : padYbetween), 2, (label==null ? 0 : padYbetween), 0), 0, 0));
 	            
 
 	            delButtons.put(delButton, iCurrentItemListIndex);
+	            addButtons.put(addButtonAtItem, iCurrentItemListIndex);
 	            upButtons.put(upButton,  iCurrentItemListIndex);
 	            downButtons.put(downButton, iCurrentItemListIndex);
                 
@@ -448,6 +486,11 @@ public class ItemTypeItemList extends ItemType {
 	            panel.add(delButton, new GridBagConstraints(x+xForAddDelButtons, y+curYPos, 1, 1, 0.0, 0.0,
 	                    GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets((label==null ? 0 : padYbetween), 2, (label==null ? 0 : padYbetween), 0), 0, 0));
 	            delButtons.put(delButton, iCurrentItemListIndex);
+
+	            panel.add(addButtonAtItem, new GridBagConstraints(x+(xForAddDelButtons*2), y+curYPos, 1, 1, 0.0, 0.0,
+	                    GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets((label==null ? 0 : padYbetween), 2, (label==null ? 0 : padYbetween), 0), 0, 0));
+	            addButtons.put(addButtonAtItem, iCurrentItemListIndex);
+	            
             }
 
             lastItemStart = (label != null ? label : delButton);
@@ -468,6 +511,7 @@ public class ItemTypeItemList extends ItemType {
                         item.setDescription(descr + " " + (iCurrentItemListIndex+1));
                     }
                     int plusY = item.displayOnGui(dlg, panel, myX, y+curYPos);
+                    EfaGuiUtils.enableAutoScrollOnFocus(item.getComponent());
                     if (item instanceof ItemTypeLabelTextfield) { //neccessary for efaBaseFrameMultisession
                     	((ItemTypeLabelTextfield) item).restoreBackgroundColor();
                     }
@@ -502,11 +546,12 @@ public class ItemTypeItemList extends ItemType {
             ((BaseDialog)dlg).updateGui();
             if (lastItemStart != null) {
                 ((BaseDialog)dlg).getScrollPane().scrollRectToVisible(lastItemStart.getBounds());
-            }
-            if (lastItemFocus != null) {
-                lastItemFocus.requestFocus();
+                if (lastItemFocus != null) {
+                	lastItemFocus.requestFocus();
+                }
             }
         }
+        
     }
 
     private void delButtonHit(ActionEvent e) {
@@ -530,6 +575,34 @@ public class ItemTypeItemList extends ItemType {
         }
     }
 
+    private void addButtonAfterPositionHit(ActionEvent e) {
+    	//no up action neccessary if there is no element
+    	if (items.size()<1) {return;}
+    	
+        int idx = addButtons.get(e.getSource());
+        if (idx < 0 || idx >= items.size()) {
+            return;
+        }
+        
+        getValueFromGui(); //save the current element status
+    	
+        //add the new item at the bottom
+        IItemType[] newitems = itemFactory.getDefaultItems(getName());
+        addItems(newitems,idx+1);
+
+        changed = true;
+        if (dlg instanceof BaseDialog) {
+            ((BaseDialog)dlg).updateGui();
+            if (lastItemStart != null) {
+                ((BaseDialog)dlg).getScrollPane().scrollRectToVisible(lastItemStart.getBounds());
+                if (lastItemFocus != null) {
+                	lastItemFocus.requestFocus();
+                }
+            }
+        }        
+    }
+    
+    
     private void upButtonHit(ActionEvent e) {
     	//no up action neccessary if there is only one element
     	if (items.size()<=1) {return;}

--- a/de/nmichael/efa/gui/BaseDialog.java
+++ b/de/nmichael/efa/gui/BaseDialog.java
@@ -10,17 +10,36 @@
 
 package de.nmichael.efa.gui;
 
-import de.nmichael.efa.*;
-import de.nmichael.efa.util.*;
-import de.nmichael.efa.util.Dialog;
-import de.nmichael.efa.core.config.EfaConfig;
-import de.nmichael.efa.core.items.*;
-import de.nmichael.efa.gui.util.AutoCompletePopupWindow;
-import de.nmichael.efa.gui.util.RoundedBorder;
+import java.awt.AWTEvent;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowEvent;
 
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
+import javax.swing.AbstractButton;
+import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextField;
+
+import de.nmichael.efa.Daten;
+import de.nmichael.efa.core.items.IItemType;
+import de.nmichael.efa.gui.util.AutoCompletePopupWindow;
+import de.nmichael.efa.util.ActionHandler;
+import de.nmichael.efa.util.Dialog;
+import de.nmichael.efa.util.EfaUtil;
+import de.nmichael.efa.util.Help;
+import de.nmichael.efa.util.International;
+import de.nmichael.efa.util.Logger;
+import de.nmichael.efa.util.Mnemonics;
 
 // @i18n complete
 public abstract class BaseDialog extends JDialog implements ActionListener {
@@ -144,6 +163,7 @@ public abstract class BaseDialog extends JDialog implements ActionListener {
             iniDialogCommonFinish();
             EfaUtil.pack(this);
             _prepared = true;
+            EfaGuiUtils.enableAutoScrollOnFocus(this);
             return true;
         } catch (Exception e) {
             Logger.log(e);

--- a/de/nmichael/efa/gui/BaseTabbedDialog.java
+++ b/de/nmichael/efa/gui/BaseTabbedDialog.java
@@ -199,8 +199,17 @@ public abstract class BaseTabbedDialog extends BaseDialog {
         updateGui(false);
     }
 
+    /**
+     * Updates the the GUI as additional elements may have been placed on it 
+     * (by ItemTypeItemList for instance). 
+     */
     public void updateGui() {
         updateGui(defaultGetGuiItemsOnUpdateGui);
+        //enableAutoScrollOnFocus is initially called in BaseDialog.prepareDialog()
+        //and should be called only once on each dialog.
+        //But as updateGUI removes all elements from the GUI and re-adds them,
+        //we need to re-initialize the AutoScroll on focus.
+        EfaGuiUtils.enableAutoScrollOnFocus(this);
     }
 
     public void updateGui(boolean readValuesFromGui) {
@@ -236,8 +245,6 @@ public abstract class BaseTabbedDialog extends BaseDialog {
                 defaultGetGuiItemsOnUpdateGui = true;
             }
         }
-
-
 
         // select an item to focus
         Vector<IItemType> v = itemsPerCategory.get( (selectedPanel != null ? selectedPanel : cats[0]));

--- a/de/nmichael/efa/gui/EfaBaseFrameMultisession.java
+++ b/de/nmichael/efa/gui/EfaBaseFrameMultisession.java
@@ -396,6 +396,9 @@ public class EfaBaseFrameMultisession extends EfaBaseFrame implements IItemListe
     	iniGuiBase();
         iniGuiMain();
         iniGuiFieldDefaultValues();
+        //we only enable autoscroll on the multisession baseframe,
+        //as this frame has elements which are added at runtime and may cause the scrollbars to appear.
+        EfaGuiUtils.enableAutoScrollOnFocus(this);
     }    
     
     private void iniGuiFieldDefaultValues() {
@@ -661,7 +664,6 @@ public class EfaBaseFrameMultisession extends EfaBaseFrame implements IItemListe
 			row[0].removeFromVisible(row[0].getValue());
 			row[1].removeFromVisible(row[1].getValue());
 		}
-
     }
 	
 

--- a/de/nmichael/efa/gui/EfaGuiUtils.java
+++ b/de/nmichael/efa/gui/EfaGuiUtils.java
@@ -9,18 +9,29 @@
  */
 package de.nmichael.efa.gui;
 
+import java.awt.Component;
+import java.awt.Container;
 import java.awt.Cursor;
 import java.awt.Desktop;
 import java.awt.FontMetrics;
 import java.awt.GridBagConstraints;
 import java.awt.Image;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.swing.JComponent;
 import javax.swing.JEditorPane;
 import javax.swing.JLabel;
+import javax.swing.JScrollPane;
+import javax.swing.JTabbedPane;
+import javax.swing.JViewport;
 import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.event.HyperlinkEvent;
 
 import de.nmichael.efa.Daten;
@@ -208,6 +219,72 @@ public class EfaGuiUtils {
                 htmlPane.setCursor(old);
             }
         });
+	}
+
+	/**
+	 * Adds a focusGained event listener on any component on the component and all it's children.
+	 * Which scrolls the focused element into view, if it is on a Scrollpane.
+	 * @param root Root component
+	 */
+	public static void enableAutoScrollOnFocus(Component root) {
+	    if (root instanceof JComponent) {
+	        final JComponent jc = (JComponent) root;
+
+	        jc.addFocusListener(new FocusAdapter() {
+	            @Override
+	            public void focusGained(FocusEvent e) {
+	                SwingUtilities.invokeLater(new Runnable() {
+	                    @Override
+	                    public void run() {
+	                    	scrollToVisible(jc);
+	                    }
+	                });
+	            }
+	        });
+	    }
+
+	    if (root instanceof Container) {
+	        Container container = (Container) root;
+	        for (Component child : container.getComponents()) {
+	            enableAutoScrollOnFocus(child);
+	        }
+	    }
+	}
+	
+	/**
+	 * If the component is on a ScrollPane, scroll the component into the visible view.
+	 * Also works on nested Tabbedpanes and Scrollpanes like in efaConfigDialog.
+	 * @param comp
+	 */
+	public static void scrollToVisible(JComponent comp) {
+	    JScrollPane scrollPane = findScrollPane(comp);
+	    if (scrollPane == null) return;
+
+	    JViewport viewport = scrollPane.getViewport();
+
+	    // Convert rect to the coordinates of the viewport
+	    Rectangle rect = SwingUtilities.convertRectangle(
+	            comp.getParent(),
+	            comp.getBounds(),
+	            viewport // viewport.getView() will not work correctly.
+	            );
+
+	    viewport.scrollRectToVisible(rect);
+	}
+	
+	/**
+	 * Get the parent ScrollPane the component is placed on. Searches for it recursively, parent by parent.
+	 * @param c component
+	 * @return Returns the parent Scrollpane, if one exists. Null otherwise
+	 */
+	private static JScrollPane findScrollPane(Component c) {
+	    while (c != null) {
+	        if (c instanceof JScrollPane) {
+	        	return (JScrollPane) c;
+	        } 
+	        c = c.getParent();
+	    }
+	    return null;
 	}
 
 }

--- a/de/nmichael/efa/gui/widgets/HTMLWidgetInstance.java
+++ b/de/nmichael/efa/gui/widgets/HTMLWidgetInstance.java
@@ -180,7 +180,7 @@ public class HTMLWidgetInstance extends WidgetInstance implements IWidgetInstanc
 	}
 
 	private JPanel getHTMLCaptionHeader(String caption, Boolean showMaximize) {
-		return WidgetInstance.getLocationHeader(caption, false, showMaximize, 
+		return WidgetInstance.getLocationHeader(caption, showMaximize, 
 				(this.isColorsActive() ? this.getHeaderBackgroundColor() : null), 
 				(this.isColorsActive() ? this.getHeaderForegroundColor() : null));
 	}	

--- a/de/nmichael/efa/gui/widgets/OpenMeteoApiParser.java
+++ b/de/nmichael/efa/gui/widgets/OpenMeteoApiParser.java
@@ -10,6 +10,7 @@ import javax.swing.ImageIcon;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import de.nmichael.efa.gui.widgets.WeatherDataForeCast.WDFStatus;
 import de.nmichael.efa.util.International;
 import de.nmichael.efa.util.Logger;
 
@@ -99,11 +100,12 @@ public class OpenMeteoApiParser {
     	weatherApiCodeToWeatherApiIconMap.put(1282, 395);
     }
 
-    public static WeatherDataForeCast parseFromOpenMeteo(JSONObject json) {
+    public static WeatherDataForeCast parseFromOpenMeteo(JSONObject json, String longitude, String latitude, int interval) {
     	
         JSONObject root = json;
         // main object with coordinates, current_weather and hourly_data
-        WeatherDataForeCast wdf = new WeatherDataForeCast();
+        WeatherDataForeCast wdf = new WeatherDataForeCast(longitude,latitude, interval);
+        wdf.setSource(WeatherWidget.WEATHER_SOURCE_OPENMETEO);
         
         try {
 
@@ -179,11 +181,11 @@ public class OpenMeteoApiParser {
 	        calculateHourlyWeatherCodeAndIcons(hourly);
 	        wdf.setHourly(hourly);
 	        
-	        wdf.setStatus(true);
+	        wdf.setStatus(WDFStatus.OK); // Download and parsing successful.
 	        wdf.setStatusMessage("");
         } catch (Exception e) {
-        	wdf.setStatus(false);
-        	wdf.setStatusMessage(e.getLocalizedMessage());
+        	wdf.setStatus(WDFStatus.Error);
+        	wdf.setStatusMessage(e.toString());
         	Logger.logdebug(e);
         }
 	    

--- a/de/nmichael/efa/gui/widgets/WeatherDataCache.java
+++ b/de/nmichael/efa/gui/widgets/WeatherDataCache.java
@@ -198,15 +198,13 @@ public class WeatherDataCache {
         	    	nextUpdateInSeconds = Math.min(nextUpdateInSeconds, current.getNextUpdateInSeconds());
         	    }
         	}
-        	Logger.logdebug(Logger.TT_WIDGETS, 5, Logger.MSG_DEBUG_METEOWIDGET, "WDCUpdate: next update in seconds: "+nextUpdateInSeconds);
 
-        	this.scheduleNext(nextUpdateInSeconds);
+        	this.scheduleNext(nextUpdateInSeconds+1);//+1 means that we surely have the next update event AFTER at least one of the items is due.
         	
         }        
         
     	/**
     	 * Handles getting the actual Weather Data from the configured data source.
-    	 * 
     	 * 
     	 * @param source
     	 * @param longitude

--- a/de/nmichael/efa/gui/widgets/WeatherDataCache.java
+++ b/de/nmichael/efa/gui/widgets/WeatherDataCache.java
@@ -1,32 +1,64 @@
 package de.nmichael.efa.gui.widgets;
 
 import java.io.BufferedReader;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.HashMap;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.zip.GZIPInputStream;
 
 import org.json.JSONObject;
 
+import de.nmichael.efa.gui.widgets.WeatherDataForeCast.WDFStatus;
 import de.nmichael.efa.util.International;
 import de.nmichael.efa.util.Logger;
 
+/*
+ * The WeatherDataCache holds a list of WeatherDataForeCasts. One item per unique location (based on their geocoordinates).
+ * 
+ * Every time a NEW weather forecast is requested, a new WDF is created in state "initial". This is for the purpose of updating
+ * the weather widget in the GUI, with a text like "Getting weather data".
+ * 
+ * This WDF in initial mode has an update time of 0 seconds, and the WDCUpdater regularily checks the WeatherDataCache items
+ * weather they need an update from the internet.
+ * 
+ * If so, the data is obtained and the resulting WDF can be either ok (update successful) or error.
+ * If it is error, we do not want the update thread to wait the standard update time (which is an hour by default).
+ * Instead, in error state the update time increases by each error that occurred. 
+ * So the first update is after 1 minute, next 3 minutes, next 5 minutes, next 7 minutes. This is somewhat of a retry pattern:
+ * after an initial error, we try again fast, and the longer the error situation persists, the longer the intervals get.
+ * 
+ * Once the weather data has been obtained successfully, the update interval changes to interval configured by the user.
+ * 
+ * The widgets on the GUI just update themselves like every minute depending on the weather data which is in the cache 
+ * at the time they need to update their widget data.
+ * 
+ */
 public class WeatherDataCache {
 
 	static WeatherDataCache instance = null;
-	
-	private HashMap<String, WeatherDataForeCast> forecasts = new HashMap<String, WeatherDataForeCast>();
+	private WDCUpdater updaterThread = null;
+	private ConcurrentHashMap<String, WeatherDataForeCast> forecasts = new ConcurrentHashMap<String, WeatherDataForeCast>();
 	private String myTempScale;
 	private String mySpeedScale;
-	private long myUpdateIntervalSeconds=60*60*24;
+	private volatile int updateCacheRegularIntervalSeconds=3600;
 	
-	static WeatherDataCache getInstance() {
+	static synchronized WeatherDataCache getInstance() {
 		if (instance == null) {
 			instance = new WeatherDataCache();
 		} 
 		return instance;
 	}
 	
+	public WeatherDataCache() {
+		Logger.logdebug(Logger.TT_WIDGETS, 5, Logger.MSG_DEBUG_METEOWIDGET, "Creating WeatherDataCache. "+updateCacheRegularIntervalSeconds);
+		updaterThread = new WDCUpdater(updateCacheRegularIntervalSeconds); 
+		updaterThread.scheduleNext(1); //Just wait a single second for the first update interval after a startup of efa.
+		updaterThread.start();
+	}
 	public void setTempScale(String value) {
 		myTempScale=value;
 	}
@@ -35,116 +67,239 @@ public class WeatherDataCache {
 		mySpeedScale=value;
 	}
 	
-	public void setUpdateIntervalSeconds(long value) {
-		myUpdateIntervalSeconds = value;
+	public void setRegularUpdateIntervalSeconds(int value) {
+		updateCacheRegularIntervalSeconds = value;
 	}
 	
+	/**
+	 * This is the main method where a WeatherWidgetInstance may request the current weather data
+	 * for a location.
+	 * @param source Source for the weatherdata (configured by the user)
+	 * @param longitude Longitude of the location
+	 * @param latitude  Latitude of the location
+	 * @return WeatherDataForecast in a special state
+	 */
 	public synchronized WeatherDataForeCast getWeatherData(String source, String longitude, String latitude) {
-		WeatherDataForeCast existing = forecasts.get(longitude+latitude);
-		if ((existing==null) || existing.needsUpdate()){
-			return getNewWeatherData(source, longitude, latitude);
+		WeatherDataForeCast existing = forecasts.get(getKey(longitude,latitude));
+		if (existing==null){
+			//only create new weather data if the cache does not contain this weather location.
+			//This is a dummy element stating "getting weather data". Obtaining the actual weather data
+			//is the job of the WDCUpdater.
+			WeatherDataForeCast wdfNew = createInitialWeatherData(source, longitude, latitude);
+			forecasts.put(getKey(longitude, latitude), wdfNew);
+			updaterThread.scheduleNext(1); //new item: we want to update this item instantly.
+			return wdfNew;
 		} else {
 			return existing;
 		}
 	}
+
+	private synchronized WeatherDataForeCast createInitialWeatherData(String source, String longitude, String latitude) {
+		// this creates a weatherdataforecast in status "initializing"
+		Logger.logdebug(Logger.TT_WIDGETS, 5, Logger.MSG_DEBUG_METEOWIDGET, "WeatherDataCache: New forecast request for "+ getKey(longitude, latitude));	
+		WeatherDataForeCast wdfNew = new WeatherDataForeCast(longitude,latitude, this.updateCacheRegularIntervalSeconds);
+		wdfNew.setNextUpdateInSeconds(0);
+		wdfNew.setSource(source);
+		return wdfNew;
+	}
 	
-	private WeatherDataForeCast getNewWeatherData(String source, String longitude, String latitude) {
-
-		if (source.equalsIgnoreCase(WeatherWidget.WEATHER_SOURCE_OPENMETEO)) {
-			try {
-
-				WeatherDataForeCast data = fetchMeteoWeather(longitude, latitude);
-				data.setSecondsUntilNextUpdate(myUpdateIntervalSeconds);
-				forecasts.put(longitude+latitude, data);
-				return data;
-
-			} catch (Exception e) {
-				Logger.logdebug(e);
-			}
-		}
-		return null;
+	private String getKey(String first, String second) {
+		return first+"#"+second;
 	}
 
-	private WeatherDataForeCast fetchMeteoWeather(String longitude, String latitude) {
+	/*
+	 * WeatherDataCacheUpdater (short: WDCUpdater)
+	 * This is a thread which has no regular update interval, but updates every time the 
+	 * WeatherDataForecast items ask it to. The WeatherDataForecast items know - depending on their state -
+	 * what the next reasonable update interval should be.
+	 * 
+	 * So if the cache has two items, the next checkup interval is the minimum refresh interval of the according items in the cache.
+	 * 
+	 */
+	private class WDCUpdater extends Thread {
 		
-		String urlStr = "https://api.open-meteo.com/v1/forecast?latitude=" + latitude + "&longitude=" + longitude
-				+ "&daily=weather_code,sunshine_duration,uv_index_max,uv_index_clear_sky_max,precipitation_sum,temperature_2m_max,temperature_2m_min,wind_speed_10m_max"
-				+ "&hourly=temperature_2m,weather_code,wind_speed_10m,wind_direction_10m,uv_index,is_day,precipitation,precipitation_probability"
-				+ "&t=temperature_2m,is_day,weather_code,wind_speed_10m,wind_direction_10m"
-				+ (myTempScale.equalsIgnoreCase(WeatherWidget.TEMP_FAHRENHEIT) ? "&temperature_unit=fahrenheit" : "")
-				+ (mySpeedScale.equalsIgnoreCase(WeatherWidget.SPEEDSCALE_MPH) ? "&wind_speed_unit=mph" : "")
-				+ "&current_weather=true"
-				+ "&timezone=GMT&timeformat=unixtime"
-				+ "&forecast_days=1&forecast_hours=24&temporal_resolution=hourly_3"
-				//+ "error" // just for testing: create an error while obtaining weather data.
-				;
+		private int connectTimeout = 15000; // 15 Seconds for slow internet connections
+		private int readTimeout = 15000;
+		private int standardUpdateIntervalSeconds;  // the standard update interval which has been set by the user
+		private final java.util.concurrent.ScheduledExecutorService scheduler = 
+				java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
+		            Thread t = new Thread(r, "WeatherDataCache.WDCUpdater");
+		            t.setDaemon(true);
+		            return t;
+				});
 
-		try {
-			Logger.log(Logger.DEBUG, International.getString("Ermittle Wetterdaten von URL:")+" "+urlStr);
+        private volatile ScheduledFuture<?> futureScheduleEvent;
 
-			String response = fetchJSonFromURL(urlStr);
-			JSONObject json = new JSONObject(response.toString());
-			return OpenMeteoApiParser.parseFromOpenMeteo(json);
-			
-		} catch (Exception e) {
-			WeatherDataForeCast tmp=new WeatherDataForeCast();
-			tmp.setStatus(false);
-			tmp.setStatusMessage(International.getString("Fehler beim Abruf der Wetterdaten.")+"\n\n"+
-					e.getLocalizedMessage());
-			tmp.setExceptionText(e.getLocalizedMessage());
-			Logger.log(Logger.WARNING, Logger.MSG_WARN_WEATHERUPDATEFAILED,e);
-			return tmp;
-		} 
-		catch (NoClassDefFoundError e1) {
-			WeatherDataForeCast tmp=new WeatherDataForeCast();
-			tmp.setStatus(false);
-			tmp.setStatusMessage(
-					International.getString("Fehler beim Abruf der Wetterdaten.")+"\n\n"+ 
-					International.getString("Vermutlich wird die JSON-Bibliothek im Java-Classpath nicht gefunden. Rebooten sie den PC (und nicht nur efa), und prüfen Sie ggfs. den Classpath (CP) runefa.sh/runefa.bat")+"\n\n"+
-					e1.getLocalizedMessage()
-					); 
-			tmp.setExceptionText(e1.getLocalizedMessage());
-			Logger.log(Logger.WARNING, Logger.MSG_WARN_WEATHERUPDATEFAILED,e1.getLocalizedMessage()+"\n\n"+e1.toString());
-			return tmp;
-		}
-	}
+        WDCUpdater(int refreshSeconds){
+        	standardUpdateIntervalSeconds=refreshSeconds;
+        }
+        
+        /**
+         * Set the next Event when the WDCUpdater checks the items in the cache wether they need an update from the internet.
+         * @param delaySeconds
+         */
+        public void scheduleNext(long delaySeconds) {
+            if (futureScheduleEvent != null) {
+                futureScheduleEvent.cancel(false);
+            }
+            long interval = (delaySeconds <= 0 ? 60 : delaySeconds);
+            futureScheduleEvent = scheduler.schedule(this::updateOnceSafe, interval, java.util.concurrent.TimeUnit.SECONDS);
+            Logger.logdebug(Logger.TT_WIDGETS, 5, Logger.MSG_DEBUG_METEOWIDGET, "WDCUpdater: next update in "+ delaySeconds+" seconds.");
+        }
 
-	public String wrapAt200(String s) {
-	    StringBuilder sb = new StringBuilder();
-	    int count = 0;
+        /* 
+         * Update the cache, and log an exception if one occurs
+         */
+        private void updateOnceSafe() {
+            try {
+                updateOnce();
+            } catch (Throwable e) {
+                Logger.logdebug(new Exception(e));
+            }
+        }
 
-	    for (String word : s.split("&")) {
-	        if (count + word.length() > 200) {
-	            sb.append('\n');
-	            count = 0;
-	        }
-	        sb.append(word).append(' ');
-	        count += word.length() + 1;
-	    }
+        public synchronized void stopMe() {
+            try {
+                if (futureScheduleEvent != null) {
+                    futureScheduleEvent.cancel(true);
+                }
+            } catch (Exception ignore) {}
+            scheduler.shutdownNow();
+        }
 
-	    return sb.toString();
-	}
+        /*
+         * Check the WDC Cache elements wether they need an update.
+         * Calculate the next scheduling event when the next check needs to take place (depending on the cache items)
+         */
+        private void updateOnce() {
+        	
+        	long nextUpdateInSeconds = updateCacheRegularIntervalSeconds; // maximum wait time for cache updates
+        	if (forecasts.size()==0) {
+        		nextUpdateInSeconds = 60; //just check every 60 seconds if the cache is empty
+    			Logger.logdebug(Logger.TT_WIDGETS, 5, Logger.MSG_DEBUG_METEOWIDGET, "WDCUpdate: No elements in cache.");
+        	}
+        	
+        	for (String key : forecasts.keySet()) { 
+        		WeatherDataForeCast current = forecasts.get(key); 
+        		Logger.logdebug(Logger.TT_WIDGETS, 5, Logger.MSG_DEBUG_METEOWIDGET, "WDCUpdate: Checking for "+ key + " Needs update: "+ current.needsUpdate());
+        	    
+        		if (current.needsUpdate()) {
+        	    	WeatherDataForeCast wdfNew = getNewWeatherData(current.getSource(),current.getIdLongitude(),current.getIdLatitude());
 
-	
-	private String fetchJSonFromURL(String urlStr) throws Exception {
-		HttpURLConnection conn = (HttpURLConnection) new URL(urlStr).openConnection();
-		conn.setRequestMethod("GET");
-		conn.setConnectTimeout(10000);//max 5 seconds for connect
-		conn.setReadTimeout(15000); // max 10 seconds for reading data
+        	    	if (wdfNew.getStatus()==WDFStatus.Error) {
+        	    		//use the error count from the previous attempt, will get increased 
+        	    		wdfNew.setStatus(WDFStatus.Error, current.getErrorCount());
+        	    		
+        	    		Logger.logdebug(Logger.TT_WIDGETS, 5, Logger.MSG_DEBUG_METEOWIDGET, "WDCUpdate: error getting forecast. "+ key + " " + wdfNew.getStatusMessage());
+        	    	}
+        	    	forecasts.put(key, wdfNew);        	    	
+        	    	nextUpdateInSeconds = Math.min(nextUpdateInSeconds, wdfNew.getNextUpdateInSeconds());
+        	    } else {
+        	    	nextUpdateInSeconds = Math.min(nextUpdateInSeconds, current.getNextUpdateInSeconds());
+        	    }
+        	}
+        	Logger.logdebug(Logger.TT_WIDGETS, 5, Logger.MSG_DEBUG_METEOWIDGET, "WDCUpdate: next update in seconds: "+nextUpdateInSeconds);
 
-		try (BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream(), "UTF-8"))) {
-			StringBuilder sb = new StringBuilder();
-			String line;
-			while ((line = reader.readLine()) != null)
-				sb.append(line);
-			
-			int status = conn.getResponseCode();
-			if (status != HttpURLConnection.HTTP_OK) {
-				throw new RuntimeException("WebServer Reply Status " + status + sb.toString());
-			}
+        	this.scheduleNext(nextUpdateInSeconds);
+        	
+        }        
+        
+    	/**
+    	 * Handles getting the actual Weather Data from the configured data source.
+    	 * 
+    	 * 
+    	 * @param source
+    	 * @param longitude
+    	 * @param latitude
+    	 * @return
+    	 */
+    	private synchronized WeatherDataForeCast getNewWeatherData(String source, String longitude, String latitude) {
 
-			return sb.toString();
-		}
-	}	 
+    		if (source.equalsIgnoreCase(WeatherWidget.WEATHER_SOURCE_OPENMETEO)) {
+    			try {
+    				WeatherDataForeCast data = fetchMeteoWeather(longitude, latitude);
+    				data.setSource(source);
+    				return data;
+    			} catch (Exception e) {
+    				Logger.logdebug(e);
+    			}
+    		}
+    		return null;
+    	}
+        
+    	private WeatherDataForeCast fetchMeteoWeather(String longitude, String latitude) {
+    		
+    		String urlStr = "https://api.open-meteo.com/v1/forecast?latitude=" + latitude + "&longitude=" + longitude
+    				+ "&daily=weather_code,sunshine_duration,uv_index_max,uv_index_clear_sky_max,precipitation_sum,temperature_2m_max,temperature_2m_min,wind_speed_10m_max"
+    				+ "&hourly=temperature_2m,weather_code,wind_speed_10m,wind_direction_10m,uv_index,is_day,precipitation,precipitation_probability"
+    				+ "&t=temperature_2m,is_day,weather_code,wind_speed_10m,wind_direction_10m"
+    				+ (myTempScale.equalsIgnoreCase(WeatherWidget.TEMP_FAHRENHEIT) ? "&temperature_unit=fahrenheit" : "")
+    				+ (mySpeedScale.equalsIgnoreCase(WeatherWidget.SPEEDSCALE_MPH) ? "&wind_speed_unit=mph" : "")
+    				+ "&current_weather=true"
+    				+ "&timezone=GMT&timeformat=unixtime"
+    				+ "&forecast_days=1&forecast_hours=24&temporal_resolution=hourly_3"
+    				//+ "error" // just for testing: create an error while obtaining weather data.
+    				;
+
+    		try {
+    			Logger.logdebug(Logger.TT_WIDGETS, 5, Logger.MSG_DEBUG_METEOWIDGET, International.getString("Ermittle Wetterdaten von URL:")+" "+urlStr);
+
+    			String response = fetchJSonFromURL(urlStr, this.connectTimeout, this.readTimeout);
+    			JSONObject json = new JSONObject(response.toString());
+    			return OpenMeteoApiParser.parseFromOpenMeteo(json, longitude,latitude, this.standardUpdateIntervalSeconds);
+    			
+    		} catch (Exception e) {
+    			WeatherDataForeCast tmp=new WeatherDataForeCast(longitude,latitude, this.standardUpdateIntervalSeconds);
+    			tmp.setStatus(WDFStatus.Error);
+    			tmp.setStatusMessage(International.getString("Fehler beim Abruf der Wetterdaten.")+"\n\n"+
+    					e.toString());
+    			tmp.setExceptionText(e.toString());
+    			Logger.log(Logger.WARNING, Logger.MSG_WARN_WEATHERUPDATEFAILED, International.getString("Fehler beim Abruf der Wetterdaten.")+e.toString());
+    			return tmp;
+    		} 
+    		catch (NoClassDefFoundError e1) {
+    			WeatherDataForeCast tmp=new WeatherDataForeCast(longitude,latitude, this.standardUpdateIntervalSeconds);
+    			tmp.setStatus(WDFStatus.Error);
+    			tmp.setStatusMessage(
+    					International.getString("Fehler beim Abruf der Wetterdaten.")+"\n\n"+ 
+    					International.getString("Vermutlich wird die JSON-Bibliothek im Java-Classpath nicht gefunden. Rebooten sie den PC (und nicht nur efa), und prüfen Sie ggfs. den Classpath (CP) runefa.sh/runefa.bat")+"\n\n"+
+    					e1.getLocalizedMessage()
+    					); 
+    			tmp.setExceptionText(e1.toString());
+    			Logger.log(Logger.WARNING, Logger.MSG_WARN_WEATHERUPDATEFAILED, International.getString("Fehler beim Abruf der Wetterdaten.")+e1.toString());
+    			return tmp;
+    		}
+    	}
+    	
+    	private String fetchJSonFromURL(String urlStr, int connectTimeout, int readTimeout) throws Exception {
+    	    HttpURLConnection conn = (HttpURLConnection) new URL(urlStr).openConnection();
+    	    conn.setRequestMethod("GET");
+    	    conn.setConnectTimeout(connectTimeout);
+    	    conn.setReadTimeout(readTimeout);
+    	    conn.setRequestProperty("Accept-Encoding", "gzip");
+
+    	    int status = conn.getResponseCode();
+    	    if (status != HttpURLConnection.HTTP_OK) {
+    	        throw new RuntimeException("HTTP " + status +" / "+conn.getResponseMessage());
+    	    }
+
+    	    InputStream in = conn.getInputStream();
+    	    if ("gzip".equalsIgnoreCase(conn.getContentEncoding())) {
+    	        in = new GZIPInputStream(in);
+    	    }
+
+    	    try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+    	        StringBuilder sb = new StringBuilder();
+    	        String line;
+    	        while ((line = reader.readLine()) != null) {
+    	            sb.append(line);
+    	        }
+    	        return sb.toString();
+    	    }
+    	}
+        
+        
+    }
+
 	
 }

--- a/de/nmichael/efa/gui/widgets/WeatherDataForeCast.java
+++ b/de/nmichael/efa/gui/widgets/WeatherDataForeCast.java
@@ -1,8 +1,18 @@
 package de.nmichael.efa.gui.widgets;
 
+import de.nmichael.efa.util.International;
+
 public class WeatherDataForeCast {
+
+	private static int INITIAL_UPDATE_INTERVAL = 5;
+	enum WDFStatus {
+        Initializing,
+        OK,
+        Error
+    }
     private long lastUpdateTimeStamp;
-	private long secondsUntilNextUpdate=90000;
+	private int nextUpdateInSeconds;
+	private int regularUpdateIntervalSeconds;
     private double latitude;
     private double longitude;
     private double elevation;
@@ -10,33 +20,63 @@ public class WeatherDataForeCast {
     private WeatherDataHourlyUnits hourlyUnits;
     private WeatherDataHourly hourly;
     private WeatherDataDaily daily;
-    private boolean status=false;
-    private String statusMessage="";
-    private String exceptionText="";
+    private WDFStatus status = WDFStatus.Initializing;
+    private String statusMessage;
+    private String exceptionText = "";
+    private int errorCount;;
+    private String source; 
     
-    public WeatherDataForeCast() {
+    private String idLongitude;
+    private String idLatitude;
+    
+    public WeatherDataForeCast(String longitude, String latitude, int standardIntervalSeconds) {
     	lastUpdateTimeStamp = System.currentTimeMillis();
+    	idLongitude = longitude;
+    	idLatitude = latitude; 
+    	statusMessage=International.getString("Ermittle Wetterdaten...");
+    	status=WDFStatus.Initializing;
+    	nextUpdateInSeconds = INITIAL_UPDATE_INTERVAL;
+    	regularUpdateIntervalSeconds = standardIntervalSeconds;
+    }
+    
+    public void setSource(String s) {
+    	source=s;
+    }
+    
+    public String getSource() {
+    	return source;
+    }
+    
+    public int getErrorCount() {
+    	return errorCount;
     }
     
     public long getLastUpdateTimeStamp() {
     	return lastUpdateTimeStamp;
     }
     
-    public long getSecondsUntilNextUpdate() {
-    	return secondsUntilNextUpdate;
+    public long getNextUpdateInSeconds() {
+    	return Math.max(1,
+    					(((lastUpdateTimeStamp+(nextUpdateInSeconds*1000))-System.currentTimeMillis())/1000));
+
     }
     
-    public void setSecondsUntilNextUpdate(long value) {
-    	if (value<secondsUntilNextUpdate) {
-    		secondsUntilNextUpdate=value;
+    public void setNextUpdateInSeconds(int value) {
+    	if (value<nextUpdateInSeconds) {
+    		nextUpdateInSeconds=value;
     	}
     }
-
-    public boolean needsUpdate() {
-    	return System.currentTimeMillis()>(lastUpdateTimeStamp+secondsUntilNextUpdate*1000);
-    }
     
-	public WeatherDataHourly getHourly() {
+    /*
+     * Calculates if the weather data is outdated and needs an update.
+     * This is so if there had been an error downloading the weather data,
+     * or the weather data is older than the update interval.
+     */
+    public boolean needsUpdate() {
+    	return (System.currentTimeMillis()>=(lastUpdateTimeStamp+nextUpdateInSeconds*1000));
+    }
+
+    public WeatherDataHourly getHourly() {
 		return hourly;
 	}
 	public void setHourly(WeatherDataHourly hourly) {
@@ -102,7 +142,6 @@ public class WeatherDataForeCast {
 	    return sb.toString();
 	}
 
-	
 	public String getExceptionText() {
 		return exceptionText;
 	}
@@ -110,12 +149,54 @@ public class WeatherDataForeCast {
 	public void setStatusMessage(String statusMessage) {
 		this.statusMessage = statusMessage;
 	}
-	public boolean getStatus() {
+	
+	public WDFStatus getStatus() {
 		return status;
 	}
-	public void setStatus(boolean status) {
+	
+	/*
+	 * Set the status of the WeatherDataForecast.
+	 * Depending of the status, the update interval is calculated.
+	 * 
+	 * So that empty weather update forecast updates after 5 seconds,
+	 * an errored forecast updates initially with a one minute interval	that increases with the amount of consecutive errors
+	 * and a ok forecast updates regulary.
+	 */
+	
+	public void setStatus(WDFStatus status, int previouseErrorCount) {
 		this.status = status;
+		
+		if (status == WDFStatus.OK) {
+			this.errorCount=0;
+			this.nextUpdateInSeconds = regularUpdateIntervalSeconds;
+		} else if (status==WDFStatus.Error) {
+			//on the first error, wait a minute.
+			//after the first error, wait one minute * errorcount*2 minutes.
+			//so 1,3,5,7,9,11... until the standard update interval is reached.
+			//we would update every standardUpdateInterval anyways.
+			this.nextUpdateInSeconds = Math.min(60+(previouseErrorCount*120), regularUpdateIntervalSeconds); 
+			this.errorCount=previouseErrorCount+1;
+		} else if (status == WDFStatus.Initializing) {
+			this.errorCount=0;
+			this.nextUpdateInSeconds = INITIAL_UPDATE_INTERVAL;
+		} else {
+			this.errorCount=0;
+			this.nextUpdateInSeconds = regularUpdateIntervalSeconds;
+		}
 	}
+	
+	public void setStatus(WDFStatus status) {
+		setStatus(status, 0);
+	}
+
+	public String getIdLongitude() {
+		return idLongitude;
+	}
+	
+	public String getIdLatitude() {
+		return idLatitude;
+	}
+
 }
 
 

--- a/de/nmichael/efa/gui/widgets/WeatherRenderer.java
+++ b/de/nmichael/efa/gui/widgets/WeatherRenderer.java
@@ -32,7 +32,7 @@ public abstract class WeatherRenderer {
 	}
 	
 	protected static JPanel getLocationHeader(String caption, Boolean showMaximize, WeatherWidgetInstance ww) {
-		return WidgetInstance.getLocationHeader(caption, false, showMaximize, ww.getStandardHeaderBackground(), ww.getStandardHeaderForeground());
+		return WidgetInstance.getLocationHeader(caption, showMaximize, ww.getStandardHeaderBackground(), ww.getStandardHeaderForeground());
 	}
 	
 	protected static ImageIcon getHourlyWeatherIcon(WeatherDataForeCast wdf, int hourlyIndex) {

--- a/de/nmichael/efa/gui/widgets/WeatherRendererError.java
+++ b/de/nmichael/efa/gui/widgets/WeatherRendererError.java
@@ -1,5 +1,6 @@
 package de.nmichael.efa.gui.widgets;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
@@ -11,7 +12,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 
 import de.nmichael.efa.Daten;
-import de.nmichael.efa.gui.util.RoundedBorder;
+import de.nmichael.efa.gui.widgets.WeatherDataForeCast.WDFStatus;
 import de.nmichael.efa.util.International;
 
 public class WeatherRendererError extends WeatherRenderer {
@@ -22,13 +23,39 @@ public class WeatherRendererError extends WeatherRenderer {
 		JTextArea errorTextArea= new JTextArea();
 		JScrollPane scrollPane = new JScrollPane();
 		
-		errorTextArea.setBackground(ww.getErrorBackground());
-		errorTextArea.setForeground(ww.getErrorForeground());
+		Color bg = null;
+		Color fg = null;
+		Color bgH = null;
+		Color fgH = null;
+		if (wdf.getStatus() == WDFStatus.Error) {
+			bg = ww.getErrorBackground();
+			fg = ww.getErrorForeground();
+			bgH = ww.getErrorHeaderBackground();
+			fgH = ww.getErrorHeaderForeground();
+		} else {
+			bg = ww.getStandardBackground();
+			fg = ww.getStandardForeground();
+			bgH = ww.getStandardHeaderBackground();
+			fgH = ww.getStandardHeaderForeground();
+		}
+
+		errorTextArea.setBackground(bg);
+		errorTextArea.setForeground(fg);
+		roundPanel.setBackground(bg);
+		roundPanel.setForeground(fg);
+		
+		roundPanel.setOpaque(true);
+
 		errorTextArea.setFont(
 				roundPanel.getFont().deriveFont((float) (Daten.efaConfig.getValueEfaDirekt_BthsFontSize())));
 		errorTextArea.setFont(errorTextArea.getFont().deriveFont(Font.BOLD));
-		errorTextArea.setText(wdf.getStatusMessage());
-		errorTextArea.setPreferredSize(new Dimension(250,400));
+		String textToDisplay=wdf.getStatusMessage();
+		if (wdf.getStatus()==WDFStatus.Initializing) {
+			textToDisplay = "\n"+textToDisplay;
+		}
+		errorTextArea.setText(textToDisplay);
+		
+		errorTextArea.setPreferredSize(new Dimension(250,(wdf.getStatus()==WDFStatus.Error ? 400 : 100)));
 		errorTextArea.setToolTipText((wdf==null ? 
 				International.getString("Ein Protokoll ist in der Logdatei (Admin-Modus: Logdatei anzeigen) zu finden.") : wdf.getExceptionText()));
 		errorTextArea.setLineWrap(true);
@@ -37,18 +64,15 @@ public class WeatherRendererError extends WeatherRenderer {
 		errorTextArea.setEditable(false);
 		errorTextArea.setCaretPosition(0);
 		
-		roundPanel.setBackground(ww.getErrorBackground());
-		roundPanel.setForeground(ww.getErrorForeground());
-		roundPanel.setBorder(new RoundedBorder(ww.getErrorForeground()));
 		
 		JPanel titlePanel = WeatherRenderer.getLocationHeader(ww.getCaption(), true, ww);
-		titlePanel.setBackground(ww.getErrorHeaderBackground());
-		titlePanel.setForeground(ww.getErrorHeaderForeground());
+		titlePanel.setBackground(bgH);
+		titlePanel.setForeground(fgH);
 		
 		errorTextArea.setBorder(BorderFactory.createEmptyBorder());
         scrollPane.setBorder(BorderFactory.createEmptyBorder());// we want no border on an inner scroll pane.
         
-        scrollPane.setPreferredSize(new Dimension(250,150));
+        scrollPane.setPreferredSize(new Dimension(250,(wdf.getStatus()==WDFStatus.Error ? 150 : 100)));
         scrollPane.getViewport().add(errorTextArea, null);	
         scrollPane.setOpaque(true);
 		

--- a/de/nmichael/efa/gui/widgets/WeatherWidget.java
+++ b/de/nmichael/efa/gui/widgets/WeatherWidget.java
@@ -317,7 +317,7 @@ public class WeatherWidget extends Widget implements IItemFactory {
 		//initialize Weather Data Cache for current widget
 		WeatherDataCache.getInstance().setSpeedScale(getWeatherSpeedScale());
 		WeatherDataCache.getInstance().setTempScale(getWeatherTempScale());
-		WeatherDataCache.getInstance().setUpdateIntervalSeconds(getUpdateInterval());
+		WeatherDataCache.getInstance().setRegularUpdateIntervalSeconds(getUpdateInterval());
 		
 		//now initialize Instances
 		Vector <WidgetInstance> returnList = new Vector <WidgetInstance>();

--- a/de/nmichael/efa/gui/widgets/WeatherWidgetInstance.java
+++ b/de/nmichael/efa/gui/widgets/WeatherWidgetInstance.java
@@ -21,6 +21,7 @@ import de.nmichael.efa.data.LogbookRecord;
 import de.nmichael.efa.data.types.DataTypeTime;
 import de.nmichael.efa.gui.util.RoundedBorder;
 import de.nmichael.efa.gui.util.RoundedPanel;
+import de.nmichael.efa.gui.widgets.WeatherDataForeCast.WDFStatus;
 import de.nmichael.efa.util.EfaUtil;
 import de.nmichael.efa.util.International;
 import de.nmichael.efa.util.Logger;
@@ -28,7 +29,7 @@ import de.nmichael.efa.util.Logger;
 public class WeatherWidgetInstance extends WidgetInstance implements IWidgetInstance {
 	private volatile JPanel mainPanel = new JPanel();
 	private RoundedPanel roundPanel = new RoundedPanel();
-	private WeatherUpdater weatherUpdater;
+	private WeatherWidgetInstanceUpdater weatherUpdater;
 	
 	private String caption;
 	private String longitude;
@@ -113,7 +114,7 @@ public class WeatherWidgetInstance extends WidgetInstance implements IWidgetInst
         });
 
 	   	try {
-	   		weatherUpdater = new WeatherUpdater(roundPanel, this, this.getCaption());
+	   		weatherUpdater = new WeatherWidgetInstanceUpdater(roundPanel, this, this.getCaption());
 	   		weatherUpdater.start();
             
         } catch(Exception e) {
@@ -314,45 +315,53 @@ public class WeatherWidgetInstance extends WidgetInstance implements IWidgetInst
 	}
 
 	/**
-	 * The WeatherUpdate obtains Weather Data in a separate thread, so that
-	 * the time for getting weather data does not affect the main thread,
-	 * and efaBoathouse is still ready for interaction with the user.
+	 * There are two independent thread types for updating weather.
+	 * WeatherWidgetInstanceUpdater: 
+	 * 		Update the rendering of the weather data for this WidgetInstance.
+	 * 		There is one thread for each WidgetInstance.
+	 * WeatherDataCache->Updater: 
+	 * 		Holds all weather data, and updates the weather forecast data regularily. 
+	 * 		There is one thread for the whole WeatherDataCache.
 	 */
-   class WeatherUpdater extends Thread {
+   class WeatherWidgetInstanceUpdater extends Thread {
 
         volatile boolean keepRunning = true;
         private JPanel panel;
         private WeatherWidgetInstance ww = null;
         private WeatherDataForeCast wdf = null;
-        private long lastWeatherUpdate = 0;
         private String theName="";
         
-        public WeatherUpdater(JPanel thePanel, WeatherWidgetInstance ww, String theName) {
+        public WeatherWidgetInstanceUpdater(JPanel thePanel, WeatherWidgetInstance ww, String theName) {
         	this.panel=thePanel;
         	this.ww = ww;
         	this.theName=theName;
         }
-
-        private boolean needsToUpdateWeather() {
-        	return (this.wdf == null || (System.currentTimeMillis() >= lastWeatherUpdate+(ww.getUpdateInterval()*1000)));
-        }
         
         public void run() {
-        	this.setName("WeatherWidget.WeatherUpdater"+" "+theName+" "+DataTypeTime.now().toString());
+        	this.setName("WeatherWidget.WeatherWidgetInstanceUpdater"+" "+theName+" "+DataTypeTime.now().toString());
             
             while (keepRunning) {
             	
             	try {
-            		//WeatherDataCache handles itself if the interval for loading new weather data is exceeded.
+            		//we just get the current weather data for the location. when it is updated, depending on its state,
+            		//is up to the WeatherDataCache. In this thread, we just update the widget contents once a minute
+            		//depending on the current state of the weatherdata.
            			wdf = WeatherDataCache.getInstance().getWeatherData(ww.getSource(), ww.getLongitude(), ww.getLatitude());
 	            	
 	            	//Use invokelater as swing threadsafe ways
 	            	SwingUtilities.invokeLater(new UpdateWeatherRunner(this.panel, wdf, ww));
 	
-	            	// check every minute if we need to update Weather data.
-	            	// this also implements that the panel gets a refresh with the already downloaded WeatherData 
-	            	// every minute. This is possibly neccessary when using weather forecast which has data for multiple timecodes a day.
-	                Thread.sleep(EfaUtil.getMilliSecondsToFullMinute()+1000);
+	                if (wdf.getStatus() == WDFStatus.OK){
+	                	Thread.sleep(EfaUtil.getMilliSecondsToFullMinute()+1000);
+	                } else {
+	                	//especially at startup time, the weather data is not yet available. 
+	                	//weatherdata itself knows depending on its errorstate, when a next update of the weatherdata is valid.
+	                	//in initial state, the next update is immediate, so we just wait for the minimum of a second.
+	                	//otherwise, we wait for a maximum of a minute to update the widget's content.
+	                	long waitTime= Math.min(EfaUtil.getMilliSecondsToFullMinute(),
+	                							1000+wdf.getNextUpdateInSeconds()*1000);
+	                	Thread.sleep(waitTime);
+	                }
 
             	} catch (InterruptedException e) {
                 	//This is when the thread gets interrupted when it is sleeping.
@@ -416,7 +425,7 @@ public class WeatherWidgetInstance extends WidgetInstance implements IWidgetInst
 			uwrInnerPanel.setName("WeatherWidget-InnerPanel");
 			uwrInnerPanel.setOpaque(false);
 			
-    		if (uwrWdf != null && uwrWdf.getStatus() == true) {
+    		if (uwrWdf != null && uwrWdf.getStatus() == WDFStatus.OK) {
         		if (getLayout().equalsIgnoreCase(WeatherWidget.WEATHER_LAYOUT_CURRENT_CLASSIC)) {
 					WeatherRendererCurrentClassic.renderWeather(uwrWdf, uwrInnerPanel, uwrWW);
 				} else if (getLayout().equalsIgnoreCase(WeatherWidget.WEATHER_LAYOUT_CURRENT_WIND)) {

--- a/de/nmichael/efa/gui/widgets/WidgetInstance.java
+++ b/de/nmichael/efa/gui/widgets/WidgetInstance.java
@@ -104,15 +104,15 @@ public abstract class WidgetInstance implements IWidgetInstance {
 		return returnList;
 	}
 
-	protected static JPanel getLocationHeader(String caption, Boolean isError, Boolean showMaximize) {
-		return getLocationHeader(caption, isError, showMaximize, null, null);
+	protected static JPanel getLocationHeader(String caption, Boolean showMaximize) {
+		return getLocationHeader(caption, showMaximize, null, null);
 	}	
 
-	protected static JPanel getLocationHeader(String caption, Boolean isError, Boolean showMaximize, Color bg, Color fg) {
+	protected static JPanel getLocationHeader(String caption, Boolean showMaximize, Color bg, Color fg) {
 		RoundedPanel titlePanel = new RoundedPanel();
 		titlePanel.setLayout(new GridBagLayout());
-		titlePanel.setBackground(isError ? Daten.efaConfig.getErrorBackgroundColor() : (bg == null ? Daten.efaConfig.getToolTipHeaderBackgroundColor() : bg));
-		titlePanel.setForeground(isError ? Daten.efaConfig.getErrorForegroundColor() : (fg == null ? Daten.efaConfig.getToolTipHeaderForegroundColor() : fg));
+		titlePanel.setBackground((bg == null ? Daten.efaConfig.getToolTipHeaderBackgroundColor() : bg));
+		titlePanel.setForeground((fg == null ? Daten.efaConfig.getToolTipHeaderForegroundColor() : fg));
 	
 		JLabel titleLabel = new JLabel();
 		titleLabel.setText(caption);

--- a/de/nmichael/efa/util/Logger.java
+++ b/de/nmichael/efa/util/Logger.java
@@ -768,6 +768,19 @@ public class Logger {
         log(type, Logger.MSG_GENERIC, msg);
     }
 
+    public static void logdebug(long topic, int level, String msg) {
+    	if (isTraceOn(topic, level)){
+    		log(Logger.DEBUG, msg);
+    	}
+    }
+    
+    public static void logdebug (long topic, int level, String key, String msg) {
+    	if (isTraceOn(topic, level)){
+    		log(Logger.DEBUG, key, msg);
+    	}
+    	
+    }
+    
     public static void logdebug(Exception e) {
         if (isTraceOn(TT_EXCEPTIONS) && logExceptions) {
             log(DEBUG, MSG_DEBUG_IGNOREDEXCEPTION, e);

--- a/eou/eou.xml
+++ b/eou/eou.xml
@@ -2,7 +2,7 @@
 <efaOnlineUpdate>
 	<Version>
         <VersionID>2.5.1#9</VersionID>
-        <ReleaseDate>17.02.2026</ReleaseDate>
+        <ReleaseDate>19.02.2026</ReleaseDate>
         <DownloadUrl>TODO</DownloadUrl>
         <DownloadSize>TODO</DownloadSize>
      	<MinimumJavaVersion>1.8</MinimumJavaVersion>
@@ -12,6 +12,8 @@
         <ShowNotice lang="en">Based on 2.5.0_01.</ShowNotice>
         <ShowNotice lang="en">If you use efaCloud, make sure your server at least supports efaCloud Version 2.3.3. It is recommended to upgrade to EfaCloud 2.4.0_12 or above.</ShowNotice>
         <Changes lang="de">
+        	<ChangeItem>Bugfix: Durchtabben durch Dialoge mit vielen Elementen (z.B. in der Konfiguration oder bei Widgets) holt immer das fokussierte Element in den Sichtbereich. Es entfällt das manuelle Scrollen.</ChangeItem>
+        	<ChangeItem>Bugfix: Bei variablen Elementen (z.B. Wetter-Orten, HTML-Seiten, Bootstypen, Crontab-Elementen) können neue Elemente an eine bestimmte Stelle eingefügt werden, statt bisher nur am Ende.</ChangeItem>
             <ChangeItem>Bugfix: Widget: Wetter-Widget: Ist standardmäßig aktiviert, aber ohne voreingestellte Wetter-Orte.</ChangeItem>
             <ChangeItem>Bugfix: Widget: Wetter-Widget: Wenn Wetterdaten z.B. direkt beim Start nicht geladen werden, findet in kürzeren Zeitintervallen eine Aktualisierung statt.</ChangeItem>
 			<ChangeItem>Bugfix: Widget: HTML Widget: Ist standardmäßig aktiviert, aber ohne voreingestellte HTML-Seiten.</ChangeItem>
@@ -19,6 +21,8 @@
 			<ChangeItem>Bugfix: Widget: Newsticker: Ist standardmäßig deaktiviert.</ChangeItem>
         </Changes>
         <Changes lang="en">
+        	<ChangeItem>Bugfix: Tab navigation through dialogs with many items (e.g., in configuration or widgets) now always brings the focused element into view. Manual scrolling is no longer required.</ChangeItem>
+			<ChangeItem>Bugfix: For variable elements (e.g., weather locations, HTML pages, boattypes, crontab entries), new items can now be inserted at a specific position instead of only at the end.</ChangeItem>
             <ChangeItem>Bugfix: Widget: Weather-Widget: Enabled by default, but no locations are set up.</ChangeItem>
             <ChangeItem>Bugfix: Widget: Weather-Widget: If weather data cannot be loaded, a retry is performed in intervals of several minutes.</ChangeItem>
 			<ChangeItem>Bugfix: Widget: HTML Widget: Enabled by default, but no HTML pages are set up.</ChangeItem>

--- a/eou/eou.xml
+++ b/eou/eou.xml
@@ -13,14 +13,14 @@
         <ShowNotice lang="en">If you use efaCloud, make sure your server at least supports efaCloud Version 2.3.3. It is recommended to upgrade to EfaCloud 2.4.0_12 or above.</ShowNotice>
         <Changes lang="de">
             <ChangeItem>Bugfix: Widget: Wetter-Widget: Ist standardmäßig aktiviert, aber ohne voreingestellte Wetter-Orte.</ChangeItem>
-            <ChangeItem>Bufgix: Widget: Wetter-Widget: Wenn Wetterdaten z.B. direkt beim Start nicht geladen werden, findet in kürzeren Zeitintervallen eine Aktualisierung statt.</ChangeItem>
+            <ChangeItem>Bugfix: Widget: Wetter-Widget: Wenn Wetterdaten z.B. direkt beim Start nicht geladen werden, findet in kürzeren Zeitintervallen eine Aktualisierung statt.</ChangeItem>
 			<ChangeItem>Bugfix: Widget: HTML Widget: Ist standardmäßig aktiviert, aber ohne voreingestellte HTML-Seiten.</ChangeItem>
 			<ChangeItem>Bugfix: Widget: HTML Widget: Hintergrund war in Metal- und Nimbus-Look nicht mit der richtigen Farbe gefüllt.</ChangeItem>
 			<ChangeItem>Bugfix: Widget: Newsticker: Ist standardmäßig deaktiviert.</ChangeItem>
         </Changes>
         <Changes lang="en">
             <ChangeItem>Bugfix: Widget: Weather-Widget: Enabled by default, but no locations are set up.</ChangeItem>
-            <ChangeItem>Bufgix: Widget: Weather-Widget: If weather data cannot be loaded, a retry is performed in intervals of several minutes.</ChangeItem>
+            <ChangeItem>Bugfix: Widget: Weather-Widget: If weather data cannot be loaded, a retry is performed in intervals of several minutes.</ChangeItem>
 			<ChangeItem>Bugfix: Widget: HTML Widget: Enabled by default, but no HTML pages are set up.</ChangeItem>
 			<ChangeItem>Bugfix: Widget: HTML Widget:Background did not have the correct color when using Metal or Nimbus look.</ChangeItem>
 			<ChangeItem>Bugfix: Widget: Newsticker: Disabled by default.</ChangeItem>

--- a/eou/eou.xml
+++ b/eou/eou.xml
@@ -13,12 +13,14 @@
         <ShowNotice lang="en">If you use efaCloud, make sure your server at least supports efaCloud Version 2.3.3. It is recommended to upgrade to EfaCloud 2.4.0_12 or above.</ShowNotice>
         <Changes lang="de">
             <ChangeItem>Bugfix: Widget: Wetter-Widget: Ist standardmäßig aktiviert, aber ohne voreingestellte Wetter-Orte.</ChangeItem>
+            <ChangeItem>Bufgix: Widget: Wetter-Widget: Wenn Wetterdaten z.B. direkt beim Start nicht geladen werden, findet in kürzeren Zeitintervallen eine Aktualisierung statt.</ChangeItem>
 			<ChangeItem>Bugfix: Widget: HTML Widget: Ist standardmäßig aktiviert, aber ohne voreingestellte HTML-Seiten.</ChangeItem>
 			<ChangeItem>Bugfix: Widget: HTML Widget: Hintergrund war in Metal- und Nimbus-Look nicht mit der richtigen Farbe gefüllt.</ChangeItem>
 			<ChangeItem>Bugfix: Widget: Newsticker: Ist standardmäßig deaktiviert.</ChangeItem>
         </Changes>
         <Changes lang="en">
             <ChangeItem>Bugfix: Widget: Weather-Widget: Enabled by default, but no locations are set up.</ChangeItem>
+            <ChangeItem>Bufgix: Widget: Weather-Widget: If weather data cannot be loaded, a retry is performed in intervals of several minutes.</ChangeItem>
 			<ChangeItem>Bugfix: Widget: HTML Widget: Enabled by default, but no HTML pages are set up.</ChangeItem>
 			<ChangeItem>Bugfix: Widget: HTML Widget:Background did not have the correct color when using Metal or Nimbus look.</ChangeItem>
 			<ChangeItem>Bugfix: Widget: Newsticker: Disabled by default.</ChangeItem>


### PR DESCRIPTION
User view:
* Scroll focused elements into view. Additional "add" buttons for variable elements.
* Weather-Widget: If weather data cannot be loaded, a retry is performed in intervals of several minutes.

Technical view:
* Bugfix: Tab navigation through dialogs with many items (e.g., in configuration or widgets) now always brings the focused element into view. Manual scrolling is no longer required.

* Bugfix: For variable elements (e.g., weather locations, HTML pages, boattypes, crontab entries), new items can now be inserted at a specific position instead of only at the end.

* Removed ErrorColors from efaConfig (a relict of earlier versions)

* Technical issue: for all BaseDialogs and efaBaseFrameMultisession, a focus listener is established which makes the currently focused element scroll into view.

* Technical issue: ItemTypeCronEntry items have been reduced in width and height, leading to a better screen layout.

* Updated WeatherDataCache for autonomous update of weatherdata info, and performing a retry if the weather data cannot get loaded.