### PR TITLE
Bugfix for multisession dialogs containing unknown boat names

### DIFF
--- a/de/nmichael/efa/gui/EfaBaseFrameMultisession.java
+++ b/de/nmichael/efa/gui/EfaBaseFrameMultisession.java
@@ -1568,7 +1568,10 @@ public class EfaBaseFrameMultisession extends EfaBaseFrame implements IItemListe
     				}
     			}
         	}
-        	return false;
+        	//if we are here, the user specified at least one unknown boat, but none of the uncertain boats could be mapped to a boat in our database.
+        	//
+        	//we cannot check if it's config is "Single/Skiff", so we return true, so that we can proceed.
+        	return true; // The 
         }
         return true; // no boat specified, so no problem with the boats
     }

--- a/eou/eou.xml
+++ b/eou/eou.xml
@@ -12,6 +12,7 @@
         <ShowNotice lang="en">Based on 2.5.0_01.</ShowNotice>
         <ShowNotice lang="en">If you use efaCloud, make sure your server at least supports efaCloud Version 2.3.3. It is recommended to upgrade to EfaCloud 2.4.0_12 or above.</ShowNotice>
         <Changes lang="de">
+        	<ChangeItem>Bugfix: Bei Multisession-Dialogen (Fahrtstart oder Nachtrag) verhindert ein unbekanntes Boot nicht mehr das Speichern.</ChangeItem>
         	<ChangeItem>Bugfix: Durchtabben durch Dialoge mit vielen Elementen (z.B. in der Konfiguration oder bei Widgets) holt immer das fokussierte Element in den Sichtbereich. Es entfällt das manuelle Scrollen.</ChangeItem>
         	<ChangeItem>Bugfix: Bei variablen Elementen (z.B. Wetter-Orten, HTML-Seiten, Bootstypen, Crontab-Elementen) können neue Elemente an eine bestimmte Stelle eingefügt werden, statt bisher nur am Ende.</ChangeItem>
             <ChangeItem>Bugfix: Widget: Wetter-Widget: Ist standardmäßig aktiviert, aber ohne voreingestellte Wetter-Orte.</ChangeItem>
@@ -21,6 +22,7 @@
 			<ChangeItem>Bugfix: Widget: Newsticker: Ist standardmäßig deaktiviert.</ChangeItem>
         </Changes>
         <Changes lang="en">
+        	<ChangeItem>Bugfix: In multisession dialog (starting a session or late entry), an unknown boat no longer blocks the save operation.</ChangeItem>
         	<ChangeItem>Bugfix: Tab navigation through dialogs with many items (e.g., in configuration or widgets) now always brings the focused element into view. Manual scrolling is no longer required.</ChangeItem>
 			<ChangeItem>Bugfix: For variable elements (e.g., weather locations, HTML pages, boattypes, crontab entries), new items can now be inserted at a specific position instead of only at the end.</ChangeItem>
             <ChangeItem>Bugfix: Widget: Weather-Widget: Enabled by default, but no locations are set up.</ChangeItem>


### PR DESCRIPTION
Bugfix: In multisession dialog (starting a session or late entry), an unknown boat no longer blocks the save operation.