### PR TITLE
Mn efa131 efacli shutdown reboot

### DIFF
--- a/de/nmichael/efa/Daten.java
+++ b/de/nmichael/efa/Daten.java
@@ -291,8 +291,20 @@ public class Daten {
 	// if not, flatLaf-3.2.5.jar may be missing in classpath.
 	public static Boolean flatLafInitializationOK = false;
 	
-	public static Boolean isShutdownRequested=false;
+	private static Boolean isShutdownRequested=false;
 
+	public static synchronized void requestShutdown() {
+		isShutdownRequested = true;
+	}
+	
+	public static synchronized void resetShutdownRequest() {
+		isShutdownRequested = false;
+	}
+	
+	public static synchronized boolean isShutdownRequested() {
+		return isShutdownRequested;
+	}
+	
 	// Applikations- PID
 	public static String applPID = "XXXXX"; // will be set in iniBase(...)
 

--- a/de/nmichael/efa/Daten.java
+++ b/de/nmichael/efa/Daten.java
@@ -292,6 +292,8 @@ public class Daten {
 	public static Boolean flatLafInitializationOK = false;
 	
 	private static Boolean isShutdownRequested=false;
+	private static Boolean isShutdownHookRunning=false;
+	private static int shutdownExitCode=0;
 
 	public static synchronized void requestShutdown() {
 		isShutdownRequested = true;
@@ -303,6 +305,26 @@ public class Daten {
 	
 	public static synchronized boolean isShutdownRequested() {
 		return isShutdownRequested;
+	}
+	
+	public static synchronized void setShutdownHookRunning() {
+		isShutdownHookRunning = true;
+	}
+	
+	public static synchronized void resetShutdownHookRunning() {
+		isShutdownHookRunning = false;
+	}
+	
+	public static synchronized boolean isShutdownHookActuallyRunning() {
+		return isShutdownHookRunning;
+	}
+	
+	public static synchronized void setShutdownExitCode(int exitCode) {
+		shutdownExitCode = exitCode;
+	}
+	
+	public static synchronized int getShutdownExitCode() {
+		return shutdownExitCode;
 	}
 	
 	// Applikations- PID
@@ -437,7 +459,12 @@ public class Daten {
 		if (program != null) {
 			program.exit(exitCode);
 		} else {
-			System.exit(exitCode);
+			Daten.setShutdownExitCode(exitCode);
+        	//when ShutdownHook is running, we shall not call System.exit() here
+        	//because the Shutdownhook will call System.exit() itself.
+			if (!Daten.isShutdownHookActuallyRunning()) {
+				System.exit(exitCode);
+			} 
 		}
 	}
 

--- a/de/nmichael/efa/Program.java
+++ b/de/nmichael/efa/Program.java
@@ -220,7 +220,12 @@ public class Program {
             Daten.efaRunning.closeServer();
             Daten.efaRunning.stopDataLockThread();
         }
-        System.exit(exitCode);
+        Daten.setShutdownExitCode(exitCode);
+        if (!Daten.isShutdownHookActuallyRunning()){
+        	//when ShutdownHook is running, we shall not call System.exit() here
+        	//because the Shutdownhook will call System.exit() itself.
+        	System.exit(exitCode);
+        }
     }
 
 }

--- a/de/nmichael/efa/cli/CLI.java
+++ b/de/nmichael/efa/cli/CLI.java
@@ -50,7 +50,7 @@ public class CLI {
     public static final String MENU_COMMAND          = "command";
     public static final String MENU_CLUBWORK_BASE	 = "clubworkbase";
     public static final String MENU_CLUBWORK_BOATHOUSE = "clubworkboathouse";
-
+    
     public static final int RC_OK                            =  0;
     public static final int RC_ERROR_LOGIN                   =  1;
     public static final int RC_ERROR_OPEN_PROJECT            =  2;
@@ -59,6 +59,7 @@ public class CLI {
     public static final int RC_NO_PERMISSION                 =  5;
     public static final int RC_COMMAND_COMPLETED_WITH_ERRORS = 10;
     public static final int RC_COMMAND_FAILED                = 11;
+    public static final int RC_INVALID_ARGUMENT              = 12;
 
     enum MODE {
         cli,
@@ -239,6 +240,12 @@ public class CLI {
         }
     }
 
+    /*
+     * efaRemote needs to be active in the efaBths instance.
+     * efaCli creates a temporary project with efaRemote storage and opens it 
+     * to check the connection and get the admin permissions.
+     * also, shutdown and reboot commands are sent to the remote instance, so that they can be used by efaCli.
+     */
     private int connect() {
         if (mode == MODE.cron) {
             return RC_OK;
@@ -399,6 +406,8 @@ public class CLI {
         if (mymenu.equals(MENU_CLUBWORK_BOATHOUSE)) {
         	return de.nmichael.efa.cli.MenuClubWorkBoatHouse.class;
         }
+
+        
         return null;
     }
 

--- a/de/nmichael/efa/cli/MenuCommand.java
+++ b/de/nmichael/efa/cli/MenuCommand.java
@@ -9,13 +9,19 @@
  */
 package de.nmichael.efa.cli;
 
-import de.nmichael.efa.util.Logger;
 import java.io.File;
 import java.util.Stack;
+import java.util.Vector;
+
+import de.nmichael.efa.Daten;
+import de.nmichael.efa.data.storage.RemoteCommand;
+import de.nmichael.efa.util.Logger;
 
 public class MenuCommand extends MenuBase {
 
     public static final String CMD_RUN  = "run";
+    public static final String CMD_EFA_SHUTDOWN = "shutdownefa";
+    public static final String CMD_EFA_RESTART = "restartefa";
 
     public MenuCommand(CLI cli) {
         super(cli);
@@ -23,6 +29,8 @@ public class MenuCommand extends MenuBase {
 
     public void printHelpContext() {
         printUsage(CMD_RUN,  "<command> [options...] [>file]", "run a command");
+        printUsage(CMD_EFA_SHUTDOWN, "", "Shut down efaBoathouse you are currently connected to");
+        printUsage(CMD_EFA_RESTART, "", "Restart efaBoathouse you are currently connected to");
     }
 
     public int runExternalCommand(String args) {
@@ -69,10 +77,70 @@ public class MenuCommand extends MenuBase {
         if (ret < 0) {
             if (cmd.equalsIgnoreCase(CMD_RUN)) {
                 return runExternalCommand(args);
-            }
+            } else if (cmd.equalsIgnoreCase(CMD_EFA_SHUTDOWN)) {
+				return restartEfaBoathouse(false, args);
+			} else if (cmd.equalsIgnoreCase(CMD_EFA_RESTART)) {
+				return restartEfaBoathouse(true, args);
+			}
             return CLI.RC_UNKNOWN_COMMAND;
         } else {
             return ret;
         }
     }
+
+	private int restartEfaBoathouse(boolean restart, String args) {
+		Vector<String> options = getArgs(args);
+		
+		if (!isArgsOkForEfaInstance(CMD_EFA_RESTART, options)) {
+			return CLI.RC_INVALID_ARGUMENT;
+		}
+		
+        if (!cli.getAdminRecord().isAllowedExitEfa()) {
+            cli.logerr("You don't have permission to access this function.");
+            return CLI.RC_NO_PERMISSION;
+        }
+        
+        RemoteCommand cmd = new RemoteCommand(Daten.project);
+        boolean result = cmd.exitEfa(restart);
+        if (result) {
+        	if (restart) {
+        		cli.loginfo("efaBoathouse restart command successfully sent to remote instance. efaCLI will now exit.");
+        	} else {
+        		cli.loginfo("efaBoathouse shutdown command successfully sent to remote instance. efaCLI will now exit.");
+        	}
+        	cli.quit(CLI.RC_OK);
+			return CLI.RC_OK;
+        } else {
+            cli.logerr("Failed to send efaBoathouse restart command to remote instance.");
+    		return CLI.RC_COMMAND_FAILED;
+        }
+
+
+	}
+	
+	private Vector<String> getArgs(String args) {
+		Vector<String> options = new Vector<String>();
+		if (args != null) {
+			String[] argsarr = args.split(" ");
+			for (String arg : argsarr) {
+				if (arg.trim().length() > 0) {
+					options.add(arg.trim());
+				}
+			}
+		}
+		return options;
+	}
+
+	private boolean isArgsOkForEfaInstance(String cmd, Vector<String> args) {
+		if (args == null) {
+			args = new Vector<String>();
+		}
+		if (args.size() != 0) {
+			printUsage("Too many arguments for command: "+ cmd, "" ,"");
+			printHelpContext();
+			return false;
+		} 
+		return true;
+		
+	}
 }

--- a/de/nmichael/efa/data/efacloud/TxRequestQueue.java
+++ b/de/nmichael/efa/data/efacloud/TxRequestQueue.java
@@ -908,7 +908,8 @@ public class TxRequestQueue implements TaskManager.RequestDispatcherIF {
                         case RQ_QUEUE_START_SYNCH_UPLOAD:
                         case RQ_QUEUE_START_SYNCH_UPLOAD_ALL:
                             // Obsolete from 2.3.1: case RQ_QUEUE_START_SYNCH_DELETE:
-                            if ((currentState == QUEUE_IS_WORKING) || (currentState == QUEUE_IS_IDLE)) {
+                        	//EFA_131: Don't start synchronisation if there is a shutdown request running.
+                            if (!Daten.isShutdownRequested() && ((currentState == QUEUE_IS_WORKING) || (currentState == QUEUE_IS_IDLE))) {
                                 if ((queues.get(TX_PENDING_QUEUE_INDEX).size() == 0) &&
                                         (queues.get(TX_BUSY_QUEUE_INDEX).size() == 0)) {
                                     // prepare synchronization

--- a/de/nmichael/efa/gui/EfaBoathouseFrame.java
+++ b/de/nmichael/efa/gui/EfaBoathouseFrame.java
@@ -469,6 +469,8 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
     	    @Override
     	    public void run() {
     	        try {
+	        		Daten.setShutdownHookRunning();
+
     	        	/* The shutdown hook is called when the JVM is shutting down because of a call to System.exit() 
     	        	   or when the user clicks the close button of the window.
     	        	   The cancel() method sets isShutdownRequested to true once it is called.
@@ -476,6 +478,8 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
     	        	   so the code will only be run if isShutdownRequested is false.
     	        	 */
     	        	if (!Daten.isShutdownRequested()) {
+    	        		// in practice, this code is only run under linux as windows always closes the main window first, 
+    	        		// which calls cancel() and sets isShutdownRequested to true, before the shutdown hooks are called.
 	    	        	final CountDownLatch latch = new CountDownLatch(1);
 	    	            Runnable r = new Runnable() {
 	    	                @Override
@@ -509,16 +513,19 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
 	    	    			//this line is neccessary as other wise efa will assume that it hasn't been shut down correctly.
 	    	                Logger.log(Logger.INFO, Logger.MSG_CORE_HALT, International.getString("PROGRAMMENDE"));
 	    	            }
+	        	        System.exit(Daten.getShutdownExitCode()); 
     	        	} else {
     	        		
     	        	}
+
     	        } catch (Throwable t) {
     	            Logger.log(Logger.ERROR, Logger.MSG_GENERIC_ERROR, "Exception in shutdown hook: " +
     	            		t.getLocalizedMessage());
     	        }
-    	    }
-    	});
 
+    	   }
+    	});
+    	
 	}
     
     private void iniApplication() {

--- a/de/nmichael/efa/gui/EfaBoathouseFrame.java
+++ b/de/nmichael/efa/gui/EfaBoathouseFrame.java
@@ -513,7 +513,9 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
 	    	    			//this line is neccessary as other wise efa will assume that it hasn't been shut down correctly.
 	    	                Logger.log(Logger.INFO, Logger.MSG_CORE_HALT, International.getString("PROGRAMMENDE"));
 	    	            }
-	        	        System.exit(Daten.getShutdownExitCode()); 
+	    	            // we cannot call System.exit here because that would be a deadlock.
+	    	            // Runtime.halt() returns the desired ShutdownExitCode.
+	        	        Runtime.getRuntime().halt(Daten.getShutdownExitCode()); 
     	        	} else {
     	        		
     	        	}

--- a/de/nmichael/efa/gui/EfaBoathouseFrame.java
+++ b/de/nmichael/efa/gui/EfaBoathouseFrame.java
@@ -483,13 +483,12 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
 	    	                    try {
 	    	                        // cancel runs synchronously and blocks until finished
 	    	                    	EfaBoathouseFrame.this.cancel(null, EFA_EXIT_REASON_SYSTEM, null, false);
-	    	                    	// yay, system exit has been done, now we can count down the latch 
-	    	                    	// and let the shutdown hook finish and the JVM to exit.
-	    	                        latch.countDown();
 	    	                    } catch (Throwable t) {
 	    	                    	Logger.log(Logger.ERROR, Logger.MSG_GENERIC_ERROR,"Exception in shutdown hook: " +
 	    	        	            		t.getLocalizedMessage());
 	    	                    } finally {
+	    	                    	// yay, system exit has been done, now we can count down the latch 
+	    	                    	// and let the shutdown hook finish and the JVM to exit.
 	    	                        latch.countDown();
 	    	                    }
 	    	                }
@@ -508,6 +507,8 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
 	    	            if (!completed) {
 	    	                Logger.log(Logger.WARNING, Logger.MSG_GENERIC_ERROR, "Shutdown: cancel() did not finish within timeout.");
 	    	            }
+    	        	} else {
+    	        		
     	        	}
     	        } catch (Throwable t) {
     	            Logger.log(Logger.ERROR, Logger.MSG_GENERIC_ERROR, "Exception in shutdown hook: " +
@@ -1481,9 +1482,9 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
 //        if (e != null) {
 //            super.processWindowEvent(e);
 //        }
+        super.cancel();
         Logger.log(Logger.INFO, Logger.MSG_EVT_EFAEXIT,
                 International.getMessage("Programmende durch {originator}", who));
-        super.cancel();
         Daten.haltProgram(exitCode);
         return true;
     }

--- a/de/nmichael/efa/gui/EfaBoathouseFrame.java
+++ b/de/nmichael/efa/gui/EfaBoathouseFrame.java
@@ -34,12 +34,13 @@ import java.util.Hashtable;
 import java.util.Stack;
 import java.util.UUID;
 import java.util.Vector;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javax.swing.BorderFactory;
 import javax.swing.ButtonGroup;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JMenuBar;
 import javax.swing.JPanel;
@@ -452,7 +453,74 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
         }
     }
 
+    /** 
+     * Installs a shutdown hook that tries to call cancel() on the EDT when the JVM is shutting down.
+     * Under Windows, shutting down a java program via task manager or some sort of kill / taskkill command,
+     * the swing application FIRST closes the main window and THEN calls the shutdown hooks (wich are also called from System.exit(N).
+     * Under Linux, we need to create a shutdown hook so that cancel() is called when shutting down the VM via kill signal.
+     * 
+     * This shutdown hook waits up to 10 seconds for cancel() to complete. This should also be enough time for efaCloud Sync task
+     * to complete if it is running, as it is usually very fast and runs every 5 minutes. 
+     * If cancel() does not complete within the timeout, a warning is logged and the JVM continues shutting down.
+     */
+    private void installShutdownHook() {
+
+    	Runtime.getRuntime().addShutdownHook(new Thread() {
+    	    @Override
+    	    public void run() {
+    	        try {
+    	        	/* The shutdown hook is called when the JVM is shutting down because of a call to System.exit() 
+    	        	   or when the user clicks the close button of the window.
+    	        	   The cancel() method sets isShutdownRequested to true once it is called.
+    	        	   We do not want the shutdown hook to be run when cancel() allready has been called, 
+    	        	   so the code will only be run if isShutdownRequested is false.
+    	        	 */
+    	        	if (!Daten.isShutdownRequested()) {
+	    	        	final CountDownLatch latch = new CountDownLatch(1);
+	    	            Runnable r = new Runnable() {
+	    	                @Override
+	    	                public void run() {
+	    	                    try {
+	    	                        // cancel runs synchronously and blocks until finished
+	    	                    	EfaBoathouseFrame.this.cancel(null, EFA_EXIT_REASON_SYSTEM, null, false);
+	    	                    	// yay, system exit has been done, now we can count down the latch 
+	    	                    	// and let the shutdown hook finish and the JVM to exit.
+	    	                        latch.countDown();
+	    	                    } catch (Throwable t) {
+	    	                    	Logger.log(Logger.ERROR, Logger.MSG_GENERIC_ERROR,"Exception in shutdown hook: " +
+	    	        	            		t.getLocalizedMessage());
+	    	                    } finally {
+	    	                        latch.countDown();
+	    	                    }
+	    	                }
+	    	            };
+	
+	    	            // The actual shutdown hook thread is not the EDT, so we need to post a Runnable to the EDT to call cancel() there,
+	    	            // Post to EDT and wait max 15 seconds for completion
+	    	            SwingUtilities.invokeLater(r);
+	    	            boolean completed = false;
+	    	            try {
+	    	                completed = latch.await(15000, TimeUnit.MILLISECONDS);
+	    	            } catch (InterruptedException ie) {
+	    	                Logger.logdebug(ie);
+	    	                Thread.currentThread().interrupt();
+	    	            }
+	    	            if (!completed) {
+	    	                Logger.log(Logger.WARNING, Logger.MSG_GENERIC_ERROR, "Shutdown: cancel() did not finish within timeout.");
+	    	            }
+    	        	}
+    	        } catch (Throwable t) {
+    	            Logger.log(Logger.ERROR, Logger.MSG_GENERIC_ERROR, "Exception in shutdown hook: " +
+    	            		t.getLocalizedMessage());
+    	        }
+    	    }
+    	});
+
+	}
+    
     private void iniApplication() {
+    	installShutdownHook();
+
         openProject((AdminRecord)null);
         openProjectLogbookClubwork();
 
@@ -1300,11 +1368,47 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
         return cancel(null, EFA_EXIT_REASON_USER, null, false);
     }
 
+    private String getRequestOriginator(int reason, AdminRecord admin) {
+		String who = "unknown";
+		switch (reason) {
+			case EFA_EXIT_REASON_USER:
+				if (admin != null) {
+					who = International.getString("Admin") + "=" + admin.getName();
+				} else {
+					who = International.getString("Nutzer");
+				}
+				break;
+			case EFA_EXIT_REASON_TIME:
+			case EFA_EXIT_REASON_IDLE:
+				who = International.getString("Zeitsteuerung");
+				who += " (" + (reason == EFA_EXIT_REASON_TIME ? "time" : "idle") + ")";
+				break;
+			case EFA_EXIT_REASON_OOME:
+				who = International.getString("Speicherüberwachung");
+				break;
+			case EFA_EXIT_REASON_AUTORESTART:
+				who = International.getString("Automatischer Neustart");
+				break;
+			case EFA_EXIT_REASON_ONLINEUPDATE:
+				who = International.getString("Online-Update");
+				break;
+			case EFA_EXIT_REASON_SYSTEM:
+				who = "Shutdown Hook / System signal";
+				break;
+		}
+		return who;
+	}
+    
     public boolean cancel(WindowEvent e, int reason, AdminRecord admin, boolean restart) {
         Dialog.IGNORE_WINDOW_STACK_CHECKS = true;
         int exitCode = 0;
-        String who = "unknown";
-        Daten.isShutdownRequested=true;
+        Daten.requestShutdown();
+        // Under Windows and JDK8, we cannot detect if the system shutdown has been initiated by the user or by the system. 
+        // so under windows, all shutdowns initiated by the operating system itself (e.g. due to update or shutdown) 
+        // will be logged as "Programmende durch Nutzer".
+        String who = getRequestOriginator(reason, admin);
+        Logger.log(Logger.INFO, Logger.MSG_EVT_EFAEXIT_REQUESTED,
+				International.getMessage("Programmende durch {originator} angefordert", who));
         switch (reason) {
             case EFA_EXIT_REASON_USER: // manuelles Beenden von efa
                 boolean byUser;
@@ -1314,7 +1418,7 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
                             admin = AdminLoginDialog.login(this, International.getString("Beenden von efa"));
                             if (admin == null) {
                                 Dialog.IGNORE_WINDOW_STACK_CHECKS = false;
-                                Daten.isShutdownRequested=false;
+                                Daten.resetShutdownRequest(); // we no longer want to shut down, as the user cancelled the admin login
                                 return false;
                             }
                         }
@@ -1365,7 +1469,9 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
                 who = International.getString("Online-Update");
                 break;
             case EFA_EXIT_REASON_SYSTEM:
-            	who = "System Signal";
+            	// Under Windows and JDK8, we cannot detect if the system shutdown has been initiated by the user or by the system.
+            	// so this only is run on Linux/MacOs systems.
+            	who = "Shutdown Hook / System signal";
             	break;
         }
         if (restart) {

--- a/de/nmichael/efa/gui/EfaBoathouseFrame.java
+++ b/de/nmichael/efa/gui/EfaBoathouseFrame.java
@@ -506,6 +506,8 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
 	    	            }
 	    	            if (!completed) {
 	    	                Logger.log(Logger.WARNING, Logger.MSG_GENERIC_ERROR, "Shutdown: cancel() did not finish within timeout.");
+	    	    			//this line is neccessary as other wise efa will assume that it hasn't been shut down correctly.
+	    	                Logger.log(Logger.INFO, Logger.MSG_CORE_HALT, International.getString("PROGRAMMENDE"));
 	    	            }
     	        	} else {
     	        		

--- a/de/nmichael/efa/gui/util/EfaBoathouseBackgroundTask.java
+++ b/de/nmichael/efa/gui/util/EfaBoathouseBackgroundTask.java
@@ -154,7 +154,7 @@ public class EfaBoathouseBackgroundTask extends Thread {
                      if (Logger.isTraceOn(Logger.TT_BACKGROUND, 5)) {
                          Logger.log(Logger.DEBUG, Logger.MSG_DEBUG_EFABACKGROUNDTASK, "EfaBoathouseBackgroundTask: doing nothing as admin mode is active.");
                      }
-                } else if (Daten.isShutdownRequested) {
+                } else if (Daten.isShutdownRequested()) {
                     if (Logger.isTraceOn(Logger.TT_BACKGROUND, 5)) {
                         Logger.log(Logger.DEBUG, Logger.MSG_DEBUG_EFABACKGROUNDTASK, "EfaBoathouseBackgroundTask: doing nothing as shutdown is requested.");
                     }
@@ -431,7 +431,7 @@ public class EfaBoathouseBackgroundTask extends Thread {
                         Logger.log(Logger.DEBUG, Logger.MSG_DEBUG_EFABACKGROUNDTASK, "EfaBoathouseBackgroundTask: stopping update of boatstatus as admin mode is active.");
                     }
                     break;
-               } else if (Daten.isShutdownRequested) {
+               } else if (Daten.isShutdownRequested()) {
                    if (Logger.isTraceOn(Logger.TT_BACKGROUND, 5)) {
                        Logger.log(Logger.DEBUG, Logger.MSG_DEBUG_EFABACKGROUNDTASK, "EfaBoathouseBackgroundTask: stopping update of boatstatus as shutdown is requested.");
                    }

--- a/de/nmichael/efa/util/Logger.java
+++ b/de/nmichael/efa/util/Logger.java
@@ -292,6 +292,7 @@ public class Logger {
     public static final String MSG_EVT_PERSONADDED = "EVT047";
     public static final String MSG_EVT_CLUBWORKOPENED = "EVT048";
     public static final String MSG_EVT_PROJECTCLOSED = "EVT049";
+    public static final String MSG_EVT_EFAEXIT_REQUESTED = "EVT050";
 
     // Backup
     public static final String MSG_BCK_BACKUPSTARTED = "BCK001";

--- a/efa_de.properties
+++ b/efa_de.properties
@@ -1394,6 +1394,7 @@ Programm-Information=Programm-Information
 Programme=Programme
 PROGRAMMENDE=PROGRAMMENDE
 Programmende_durch_{originator}=Programmende durch {1}
+Programmende_durch_{originator}_angefordert=Programmende durch {1} angefordert
 Programmende_veranla\u00dft;_versuche,_Kommando__{cmd}__auszuf\u00fchren...=Programmende veranla\u00dft; versuche, Kommando ''{1}'' auszuf\u00fchren...
 Programminformationen_konnten_nicht_ermittelt_werden=Programminformationen konnten nicht ermittelt werden
 Programminterner_Fehler_aufgetreten._BoatReservationRecord_ist_versionized,_darf_dies_aber_nicht_sein._Bitte_melde_diesen_Fehler_an_den_EFA-Programmierer.=Programminterner Fehler aufgetreten. BoatReservationRecord ist versionized, darf dies aber nicht sein. Bitte melde diesen Fehler an den EFA-Programmierer.

--- a/efa_en.properties
+++ b/efa_en.properties
@@ -1402,6 +1402,7 @@ Programm-Information=Program Information
 Programme=Programs
 PROGRAMMENDE=PROGRAM TERMINATION
 Programmende_durch_{originator}=Program termination by {1}
+Programmende_durch_{originator}_angefordert=Program termination requested by {1}.
 Programmende_veranla\u00DFt;_versuche,_Kommando__{cmd}__auszuf\u00FChren...=Program termination initiated; trying to execute command ''{1}'' ...
 Programminformationen_konnten_nicht_ermittelt_werden=Program information could not be determined
 PROGRAMMSTART=PROGRAM START

--- a/efa_fr.properties
+++ b/efa_fr.properties
@@ -1509,6 +1509,7 @@ Probieren_Sie_die_Schriftart_Piboto_oder_Liberation_Sans=Essayez la police 'Pibo
 Probieren_Sie_die_Schriftart_Arial_oder_Segoe_UI=Essayez la police 'Arial' oder 'Segoe UI'
 Programme=Programmes
 Programmende_durch_{originator}=Arr\u00EAt du programme par {1}
+Programmende_durch_{originator}_angefordert=Arr\u00EAt du programme d\u00E9marr\u00E9; par {1}.
 Programmende_veranla\u00DFt;_versuche,_Kommando__{cmd}__auszuf\u00FChren...=Arr\u00EAt du programme d\u00E9marr\u00E9; essayez la commande  ''{1}'' ...
 PROGRAMMENDE=FIN DU PROGRAMME
 Programm-Information=\u00C0 propos

--- a/tools/KillJavaVMForWindows.ps1
+++ b/tools/KillJavaVMForWindows.ps1
@@ -1,0 +1,85 @@
+<#
+  KillJavaVMForWindows.ps1
+  - looks for all java or javaw processes. Kills them "softly" unless -Force is given as parameter. 
+  - Optional: -Pattern "mainclassname" looks for th/is pattern in the command line of the java/javaw process
+    and only kills the matching processes. 
+  - Optional: -Force implies a forced kill with /F /T if the soft kill does not work.
+#>
+
+param(
+  [string]$Pattern = "",
+  [switch]$Force = $false
+)
+
+function Log {
+  param([string]$msg, [string]$level = "INFO")
+  $time = (Get-Date).ToString("s")
+  Write-Output "[$time] [$level] $msg"
+}
+
+# 1) Find all java/javaw Prozesses
+$allJava = Get-CimInstance Win32_Process |
+  Where-Object { $_.Name -match '^(java|javaw)\.exe$' -or ($_.CommandLine -and $_.CommandLine -match '\bjava\b') } |
+  Select-Object ProcessId, Name, @{Name='CommandLine';Expression={if ($_.CommandLine) { $_.CommandLine } else { "<keine Kommandozeile>" }}}
+
+if (-not $allJava) {
+  Log "Did not find any java/javaw processes." "WARN"
+  exit 0
+}
+
+# 2) Always list the java processes in a table and in detail 
+Log "List of all running java/javaw processes:"
+$allJava | Format-Table -AutoSize
+
+Log "Each java/javaw process with details, one row per process"
+foreach ($p in $allJava) {
+  Write-Output ("PID: {0}  Name: {1}`nCmd: {2}`n" -f $p.ProcessId, $p.Name, $p.CommandLine)
+}
+
+# 3) if a filter pattern is provided, check which of the java processes match
+if ($Pattern) {
+  $matches = $allJava | Where-Object { $_.CommandLine -and $_.CommandLine -like "*$Pattern*" }
+  if (-not $matches) {
+    Log "None of the java processes match pattern '$Pattern'." "ERROR"
+    exit 2
+  }
+} else {
+  $matches = $allJava
+}
+
+# 4) only kill java processes if there is only one running, or multiple processes are running and
+# a pattern has been provided.
+if (-not $Pattern -and $allJava.Count -gt 1) {
+  Log "Mehrere Java-Prozesse gefunden und kein Pattern angegeben. Automatisches Beenden wird abgebrochen, um falsches Beenden zu vermeiden." "ERROR"
+  exit 3
+}
+
+# 5) Non-interaktive soft kill of the selected PIDs
+$pidsToKill = $matches | Select-Object -ExpandProperty ProcessId
+
+foreach ($pit in $pidsToKill) {
+  Log "Sending soft Kill command to PID $pit"
+  $out = & taskkill /PID $pit 2>&1
+  Log $out
+  $exit = $LASTEXITCODE
+  if ($exit -ne 0) {
+    Log "taskkill Exit Code $exit for PID $pit." "WARN"
+    if ($Force) {
+      Log "Force option applied: trying forced kill for PID $pit mit /F /T."
+      $out2 = & taskkill /PID $pit /F /T 2>&1
+      Log $out2
+      $exit2 = $LASTEXITCODE
+      if ($exit2 -ne 0) {
+        Log "Forced kill of PID $pit failed (ExitCode $exit2)." "ERROR"
+      } else {
+        Log "Forced kill of PID $pit successful." "INFO"
+      }
+    } else {
+      Log "Process PID $pit did not react to soft kill. Use parameter -Force, to apply forced kill. /F /T zu verwenden." "WARN"
+    }
+  } else {
+    Log "PID $pit successfully terminated." "INFO"
+  }
+}
+
+exit 0

--- a/tools/killEfaBthsOnWindows.bat
+++ b/tools/killEfaBthsOnWindows.bat
@@ -1,0 +1,1 @@
+powershell -ExecutionPolicy Bypass -File .\KillJavaVMForWindows.ps1 -Pattern "de.nmichael.efa.boathouse.Main" 


### PR DESCRIPTION
- efaBths now uses a shutdown hook 
  - so that when under linux a 'kill' signal is sent to efa PID, efa will shut down normally.
  - the shutdown hook is not used under windows as windows JVMs behave differently to a kill signal.
  - as we still use JDK8, there is no native way to detect if the shutdown of efaBths has been initiated from within the program or an operating system's signal.
  - under linux, the shuthook hook is not executed when rebooting the machine while efaBths is running. 
  - the tools directory provides a powershell script and a windows batch file to send 'kill' to efaBoathouse processes 
  - the shutdown hook does not work if a dialog is open in efa.

- efaBths can be shut down or restarted using efaCLI
  - efaCLI.sh command shutdownefa   
  - efaCLI.sh command restartefa
  - these commands can only be run by an admin who has the permission to close efaBths.

- efaCloud won't start an upload sync if shutdown has been requested (no matter what the source of the shutdownrequest is)