### PR TITLE
Extension: BoatListDialog/PersonListDialog

### DIFF
--- a/de/nmichael/efa/core/config/EfaConfig.java
+++ b/de/nmichael/efa/core/config/EfaConfig.java
@@ -1484,21 +1484,21 @@ public class EfaConfig extends StorageObject implements IItemFactory {
 					International.getString("Verzögerung, bis Tooltip ausgeblendet wird (msec)")));
 
 			// additional fields in boatlist
-			addHeader("efaGuiBoathouseBoatListsAddFieldsHeader", IItemType.TYPE_EXPERT,
+			addHeader("efaGuiBoathouseBoatListsAddFieldsHeader", IItemType.TYPE_PUBLIC,
 					BaseTabbedDialog.makeCategory(CATEGORY_BOATHOUSE, CATEGORY_GUI_BOATLIST),
 					International.getString("Zusätzliche Felder in der Bootsliste"), 3);
 			
 			addParameter(efaDirekt_BoathouseExtBoatField1 = new ItemTypeStringList("efaGuiBoathouseBoatListsAddFieldsBoat1",
 					"", 
 					makeExtdFieldsArray(STRINGLIST_VALUES, boatExtFields),
-					makeExtdFieldsArray(STRINGLIST_DISPLAY, boatExtFields), IItemType.TYPE_EXPERT,
+					makeExtdFieldsArray(STRINGLIST_DISPLAY, boatExtFields), IItemType.TYPE_PUBLIC,
 					BaseTabbedDialog.makeCategory(CATEGORY_BOATHOUSE, CATEGORY_GUI_BOATLIST),
 					International.getString("Bootsliste - Zusatzfeld 1")));
 
 			addParameter(efaDirekt_BoathouseExtBoatField2 = new ItemTypeStringList("efaGuiBoathouseBoatListsAddFieldsBoat2", 
 					"", 
 					makeExtdFieldsArray(STRINGLIST_VALUES, boatExtFields),
-					makeExtdFieldsArray(STRINGLIST_DISPLAY, boatExtFields), IItemType.TYPE_EXPERT,
+					makeExtdFieldsArray(STRINGLIST_DISPLAY, boatExtFields), IItemType.TYPE_PUBLIC,
 					BaseTabbedDialog.makeCategory(CATEGORY_BOATHOUSE, CATEGORY_GUI_BOATLIST),
 					International.getString("Bootsliste - Zusatzfeld 2")));
 			efaDirekt_BoathouseExtBoatField2.setPadding(0, 0, 0, 20);
@@ -1506,19 +1506,19 @@ public class EfaConfig extends StorageObject implements IItemFactory {
 			addParameter(efaDirekt_BoathouseExtPersonField1 = new ItemTypeStringList("efaGuiBoathouseBoatListsAddFieldsPerson1", 
 					"",
 					makeExtdFieldsArray(STRINGLIST_VALUES, personExtFields),
-					makeExtdFieldsArray(STRINGLIST_DISPLAY, personExtFields), IItemType.TYPE_EXPERT,
+					makeExtdFieldsArray(STRINGLIST_DISPLAY, personExtFields), IItemType.TYPE_PUBLIC,
 					BaseTabbedDialog.makeCategory(CATEGORY_BOATHOUSE, CATEGORY_GUI_BOATLIST),
 					International.getString("Personenliste - Zusatzfeld 1")));
 
 			addParameter(efaDirekt_BoathouseExtPersonField2 = new ItemTypeStringList("efaGuiBoathouseBoatListsAddFieldsPerson2", 
 					"",
 					makeExtdFieldsArray(STRINGLIST_VALUES, personExtFields),
-					makeExtdFieldsArray(STRINGLIST_DISPLAY, personExtFields), IItemType.TYPE_EXPERT,
+					makeExtdFieldsArray(STRINGLIST_DISPLAY, personExtFields), IItemType.TYPE_PUBLIC,
 					BaseTabbedDialog.makeCategory(CATEGORY_BOATHOUSE, CATEGORY_GUI_BOATLIST),
 					International.getString("Personenliste - Zusatzfeld 2")));
 
 			addParameter(efaDirekt_ExtendedFieldsOnFirstPageInEditDialog = new ItemTypeBoolean(
-					"efaGuiBoathouseBoatListsExtdFieldsOnFirstPageInEditDialog", true, IItemType.TYPE_EXPERT,
+					"efaGuiBoathouseBoatListsExtdFieldsOnFirstPageInEditDialog", true, IItemType.TYPE_PUBLIC,
 					BaseTabbedDialog.makeCategory(CATEGORY_BOATHOUSE, CATEGORY_GUI_BOATLIST), International.getString(
 							"In Bearbeitungsdialogen die ausgewählten Felder auf der ersten Seite darstellen")));			
 			

--- a/de/nmichael/efa/core/items/ItemTypeBoatstatusList.java
+++ b/de/nmichael/efa/core/items/ItemTypeBoatstatusList.java
@@ -561,8 +561,7 @@ public class ItemTypeBoatstatusList extends ItemTypeList {
    	    			}
    	    		}
 
-   	    		StringBuilder sbResult = new StringBuilder(200);
-   	    		//concat is the fastest way to build strings
+   	    		StringBuilder sbResult = new StringBuilder(300);
    	    		sbResult.append("<html><body><table border=\"0\"><tr ");
    	    		sbResult.append(this.cacheToolTipBgColorText);
    	    		sbResult.append("><td align=\"left\"><b>");
@@ -661,9 +660,6 @@ public class ItemTypeBoatstatusList extends ItemTypeList {
 						.append("</td></tr>");
 					}
 	    		}
-		    		
-
-
    	    	
    	    		sbResult.append("</table></body></html>");
    	    		return sbResult.toString();

--- a/de/nmichael/efa/core/items/ItemTypeList.java
+++ b/de/nmichael/efa/core/items/ItemTypeList.java
@@ -327,7 +327,7 @@ public class ItemTypeList extends ItemType implements ActionListener, DocumentLi
 
             // Compute maximum pixels available for secondary given reserved gap of 40px
             // Secondary must start at xSecLeft >= x + leftWidth + reservedGapBetweenSides
-            int maxSecPx = rightX - (x + leftWidth + reservedGapBetweenSides);
+            int maxSecPx = rightX - (x + leftWidth + reservedGapBetweenSides + selectionBarPadding); // also consider selection bar padding to avoid overlap with rounded corners
             String secToDraw = secondary;
 
             if (maxSecPx <= 0) {
@@ -362,8 +362,21 @@ public class ItemTypeList extends ItemType implements ActionListener, DocumentLi
                 // add width of three spaces
                 int spacesW = fmStandard.stringWidth("   ");
                 int xTertiary = xAfterPrimary + spacesW;
+                
+                String tertToDraw = tertiaryPart;
+                int maxTertPx = rightX - (xTertiary + selectionBarPadding);
+                if (maxTertPx <= 0) {
+                    // no space for secondary (even zero), don't draw it
+                    tertToDraw = "";
+                } else {
+                    // truncate secondary to maxSecPx if necessary
+                    if (fmStandard.stringWidth(tertiaryPart) > maxTertPx) {
+                        // reuse outer class truncateToWidth (available because we're inner class)
+                        tertToDraw = truncateToWidth(fmStandard, tertiaryPart, maxTertPx);
+                    }
+                }
                 g.setColor(tertiaryColor);
-                g.drawString(tertiaryPart, xTertiary, yText);
+                g.drawString(tertToDraw, xTertiary, yText);
             } else {
                 // only primary
                 g.setColor(normalFg);
@@ -505,7 +518,8 @@ public class ItemTypeList extends ItemType implements ActionListener, DocumentLi
 
     public void addItem(String text, String toolTipText, String secondaryItem, String tertiaryItem, Object object, boolean separator, char separatorHotkey,
             String image, Color[] colors) {
-        data.addElement(new ItemTypeListData(text, toolTipText, secondaryItem, tertiaryItem, object, separator, separatorHotkey, image, colors));
+		data.addElement(new ItemTypeListData(text, toolTipText, secondaryItem, tertiaryItem, object, separator,
+				separatorHotkey, image, colors));
         filter();
     }
 

--- a/de/nmichael/efa/data/BoatRecord.java
+++ b/de/nmichael/efa/data/BoatRecord.java
@@ -28,6 +28,7 @@ import javax.swing.JDialog;
 
 import de.nmichael.efa.Daten;
 import de.nmichael.efa.core.config.AdminRecord;
+import de.nmichael.efa.core.config.EfaConfig;
 import de.nmichael.efa.core.config.EfaTypes;
 import de.nmichael.efa.core.items.IItemFactory;
 import de.nmichael.efa.core.items.IItemListenerDataRecordTable;
@@ -1012,6 +1013,52 @@ public class BoatRecord extends DataRecord implements IItemFactory, IItemListene
         return super.getAsText(fieldName);
     }
 
+    
+    /**
+	 * Returns a string with all field values separated by ";".
+	 * This is intended to used ONLY for filtering (checkbox filter set to "true") of records in the DataListDialog.
+	 * Do not use this for any other purpose, as the output format is not defined and may change without notice.
+	 * 
+	 * The field order is the same as defined in the respective DataRecord subclass.
+	 * Fields with empty or null values are not included in the output.
+	 * Also, some technical fields are not included in the output (LastModified, ChangeCount, ValidFrom, InvalidFrom, Invisible, Deleted).
+	 * 
+	 * Extension: for the weight field, the weight unit is added to the value, e.g. "500kg", 
+	 * if the weight is greater than 0 and a default weight unit is defined in the configuration.
+	 */
+    @Override
+    public String getAllFieldsAsSeparatedText() {
+        StringBuilder b = new StringBuilder();
+        for (int i=0; i<getFieldCount(); i++) {
+            if (b.length() > 1) {
+                b.append(";");
+            }
+            String fieldName = getFieldName(i);
+            if (fieldName!= null && fieldName.length() > 0 
+            		&& !fieldName.equals(LASTMODIFIED)
+            		&& !fieldName.equals(CHANGECOUNT) 
+            		&& !fieldName.equals(VALIDFROM) 
+            		&& !fieldName.equals(INVALIDFROM) 
+            		&& !fieldName.equals(INVISIBLE) 
+            		&& !fieldName.equals(DELETED)) {
+            		String v=null;
+            		if (fieldName.equals(MAXCREWWEIGHT)) {
+            			int w = getMaxCrewWeight();
+            			if (w > 0) {
+            				v = Integer.toString(w).concat(Daten.efaConfig.getValueDefaultWeightUnit());
+            			}
+            		} else {
+            			v = getAsText(fieldName);
+            		}
+		            if (v != null && v.length() > 0) {
+		                b.append(v);
+		            }
+            }
+        }
+        return b.toString();
+
+	}
+    
     public boolean setFromText(String fieldName, String value) {
         if (fieldName.equals(TYPEVARIANT)) {
             DataTypeList list = DataTypeList.parseList(value, IDataAccess.DATA_INTEGER);
@@ -1283,16 +1330,35 @@ public class BoatRecord extends DataRecord implements IItemFactory, IItemListene
     }    
 
     public TableItemHeader[] getGuiTableHeader() {
-        TableItemHeader[] header = new TableItemHeader[3];
-        header[0] = new TableItemHeader(International.getString("Name"));
-        header[1] = new TableItemHeader(International.getString("Bootstyp"));
-        header[2] = new TableItemHeader(International.getString("Eigentümer"));
-        return header;
+    	if (isBoatExtensionSetupAvailable()) {
+	    	TableItemHeader[] header = new TableItemHeader[4];
+	        header[0] = new TableItemHeader(International.getString("Name"));
+	        header[1] = new TableItemHeader(International.getString("Erweiterung"));
+	        header[2] = new TableItemHeader(International.getString("Bootstyp"));
+	        header[3] = new TableItemHeader(International.getString("Eigentümer"));
+	        return header;
+    	}
+    	else {
+	    	TableItemHeader[] header = new TableItemHeader[3];
+	        header[0] = new TableItemHeader(International.getString("Name"));
+	        header[1] = new TableItemHeader(International.getString("Bootstyp"));
+	        header[2] = new TableItemHeader(International.getString("Eigentümer"));
+	        return header;
+    	}
     }
 
+    private boolean isBoatExtensionSetupAvailable() {
+		return Daten.efaConfig.getValueEfaDirektBoathouseExtBoatField1().length() > 0 ||
+				Daten.efaConfig.getValueEfaDirektBoathouseExtBoatField2().length() > 0;
+	}
+    
     public TableItem[] getGuiTableItems() {
-        TableItem[] items = new TableItem[3];
+        
+        Boolean hasExtension = isBoatExtensionSetupAvailable();
+
+        TableItem[] items= new TableItem[hasExtension ? 4 : 3];
         items[0] = new TableItem(getQualifiedName());
+        
         String type = "";
         if (getNumberOfVariants() > 0) {
             type = getDetailedBoatType(0);
@@ -1300,26 +1366,87 @@ public class BoatRecord extends DataRecord implements IItemFactory, IItemListene
         if (getNumberOfVariants() > 1) {
             type = type + " ...";
         }
-        items[1] = new TableItem(type);
-        items[2] = new TableItem(getOwner());
+        String tooltip = this.createTooltipForGroups(hasExtension);
+        if (hasExtension) {
+        	items[1] = new TableItem(getBoatExtension(false));
+        	items[1].setToolTipText(tooltip);
+        }
+        items[hasExtension ? 2 : 1] = new TableItem(type);
+        items[hasExtension ? 3 : 2] = new TableItem(getOwner());
         items[0].addIcon(this.createGroupPieIcon(16,16));
-        items[0].setToolTipText(this.createTooltipForGroups());
+        items[0].setToolTipText(tooltip);
         return items;
     }
 
-    private ImageIcon createGroupPieIcon(int iconWidth, int iconHeight) {
+    private String getBoatExtension(boolean withFieldNames) {
+    	StringBuilder result = new StringBuilder(200);
+    	String field1Name = Daten.efaConfig.getValueEfaDirektBoathouseExtBoatField1();
+    	String field2Name = Daten.efaConfig.getValueEfaDirektBoathouseExtBoatField2();
+    	String field1Value=null;
+    	String field2Value=null;
+    	String field1DisplayName="";
+    	String field2DisplayName="";
+    	
+    	if (field1Name.length() > 0) {
+			field1Value = getAsString(field1Name);
+			if (field1Value !=null && field1Name.equals(BoatRecord.MAXCREWWEIGHT)) {
+				field1Value=field1Value.concat(Daten.efaConfig.getValueDefaultWeightUnit());
+			}
+			if (withFieldNames && field1Value != null && !field1Value.isEmpty()) {
+				field1DisplayName = EfaConfig.boatExtFields.get(field1Name);
+			}
+		}
+    	if (field2Name.length() > 0) {
+			field2Value = getAsString(field2Name);
+			if (field2Value !=null && field2Name.equals(BoatRecord.MAXCREWWEIGHT)) {
+				field2Value=field2Value.concat(Daten.efaConfig.getValueDefaultWeightUnit());
+			}
+			if (withFieldNames && field2Value != null && !field2Value.isEmpty()) {
+				field2DisplayName = EfaConfig.boatExtFields.get(field2Name);
+			}
+		}
+    	
+		if ((field1Value!=null && !field1Value.isEmpty()) || (field2Value!=null && !field2Value.isEmpty())) {
+			if (withFieldNames) {       		
+				result.append((field1Value!=null && !field1Value.isEmpty() ? "<tr><td align=left>"+field1DisplayName + "</td><td>" + field1Value +"</td></tr>" : ""));
+				result.append((field2Value!=null && !field2Value.isEmpty() ? "<tr><td align=left>"+field2DisplayName + "</td><td>" + field2Value +"</td></tr>" : ""));
+
+			} else {
+				result.append((field1Value!=null 
+					? field1Value.concat((field2Value!=null ? ", " + field2Value : "")) 
+					: (field2Value!=null ? field2Value : "")));
+			}
+		}
+		
+    	return result.toString();
+	}
+
+	private ImageIcon createGroupPieIcon(int iconWidth, int iconHeight) {
     	 Color[] colors = this.getBoatGroupsPieColors(null); 
     	 return (colors !=null ? EfaUtil.createColorPieIcon(colors, iconWidth, iconHeight) : null);
     }
     
-    private String createTooltipForGroups() {
+    private String createTooltipForGroups(Boolean hasExtension) {
     	String result = this.getAllowedGroupsAsNameString(System.currentTimeMillis());
-    	if (result!=null && !result.isEmpty()) {
-    		return International.getString("Gruppen")+":\n   "+result;
+    	if ((result!=null && !result.isEmpty())||hasExtension) {
+       		String toolTipBgColorText=(Daten.efaConfig.getToolTipSpecialColors() ? "bgcolor=\"#"+EfaUtil.getColor(Daten.efaConfig.getToolTipHeaderBackgroundColor())+"\"": "");
+       		String toolTipFontColorOpeningTag = (Daten.efaConfig.getToolTipSpecialColors() ? "<font color=\"#"+EfaUtil.getColor(Daten.efaConfig.getToolTipHeaderForegroundColor())+"\">": "");
+       		String toolTipFontColorClosingTag = (Daten.efaConfig.getToolTipSpecialColors() ? "</font>": "");
+    		
+    		StringBuilder sb = new StringBuilder(200);
+    		sb.append("<html><body><table border=0><tr ")
+    		.append(toolTipBgColorText)
+    		.append("><td align=left><b>")
+    		.append(toolTipFontColorOpeningTag).append(EfaUtil.escapeHtml(getQualifiedName())).append("</b></td></tr>"); // to ensure multi-line tooltip
+    		sb.append(toolTipFontColorClosingTag).append(getBoatExtension(true)); // with field names
+    		if (result!=null && !result.isEmpty()) {
+    			sb.append("<tr><td align=left>").append(International.getString("Gruppen")).append("</td><td>"+EfaUtil.escapeHtml(result)+"</td></tr>");
+    		}
+    		return sb.toString();
+    		//return this.getQualifiedName()+ International.getString("Gruppen")+":\n   "+result;
     	} else {
     		return null;
     	}
-    		
     }
     
     /**

--- a/de/nmichael/efa/data/PersonRecord.java
+++ b/de/nmichael/efa/data/PersonRecord.java
@@ -20,6 +20,7 @@ import javax.swing.ImageIcon;
 
 import de.nmichael.efa.Daten;
 import de.nmichael.efa.core.config.AdminRecord;
+import de.nmichael.efa.core.config.EfaConfig;
 import de.nmichael.efa.core.config.EfaTypes;
 import de.nmichael.efa.core.items.IItemFactory;
 import de.nmichael.efa.core.items.IItemType;
@@ -490,6 +491,23 @@ public class PersonRecord extends DataRecord implements IItemFactory {
         return groups.getGroupsForPerson(getId(), getValidFrom(), getInvalidFrom() - 1);
     }
 
+    public Vector<String> getGroupListAsVector() {
+		GroupRecord[] groupList = getGroupList();
+		Vector<String> v = new Vector<String>();
+		for (int i = 0; groupList != null && i < groupList.length; i++) {
+			v.add(groupList[i].getQualifiedName());
+		}
+		return v;
+	}
+    
+    public String getGroupsAsNameString() {
+        Vector<String> v = getGroupListAsVector();
+        if (v == null || v.size() == 0) {
+            return "";
+        }
+        return EfaUtil.vector2string(v, ", ");
+    }
+    
     public void setFreeUse1(String s) {
         setString(FREEUSE1, s);
     }
@@ -885,70 +903,132 @@ public class PersonRecord extends DataRecord implements IItemFactory {
     	return defaultCategory;
     }    
     
+    private boolean isPersonExtensionSetupAvailable() {
+		return Daten.efaConfig.getValueEfaDirektBoathouseExtPersonField1().length() > 0 ||
+				Daten.efaConfig.getValueEfaDirektBoathouseExtPersonField2().length() > 0;
+	}
     public TableItemHeader[] getGuiTableHeader() {
-        TableItemHeader[] header = new TableItemHeader[4];
+    	Boolean hasExtension = isPersonExtensionSetupAvailable();
+        TableItemHeader[] header = new TableItemHeader[hasExtension ? 5 : 4];
+        
         if (Daten.efaConfig.getValueNameFormatIsFirstNameFirst()) {
             header[0] = new TableItemHeader(International.getString("Vorname"));
             header[1] = new TableItemHeader(International.getString("Nachname"));
-            header[2] = new TableItemHeader(International.getString("Geburtstag"));
-            header[3] = new TableItemHeader(International.getString("Status"));
         } else {
             header[0] = new TableItemHeader(International.getString("Nachname"));
             header[1] = new TableItemHeader(International.getString("Vorname"));
-            header[2] = new TableItemHeader(International.getString("Geburtstag"));
-            header[3] = new TableItemHeader(International.getString("Status"));
-        }
+		}
+        if (hasExtension) {
+			header[2] = new TableItemHeader(International.getString("Erweiterung"));
+		} 
+        header[hasExtension ? 3 : 2] = new TableItemHeader(International.getString("Geburtstag"));
+        header[hasExtension ? 4 : 3] = new TableItemHeader(International.getString("Status"));
         return header;
     }
 
     public TableItem[] getGuiTableItems() {
-        TableItem[] items = new TableItem[4];
+    	Boolean hasExtension = isPersonExtensionSetupAvailable();
+        TableItem[] items = new TableItem[hasExtension ? 5 : 4];
         if (Daten.efaConfig.getValueNameFormatIsFirstNameFirst()) {
             items[0] = new TableItem(getFirstName());
             items[1] = new TableItem(getLastName());
-            items[2] = new TableItem(getBirthday());
-            items[3] = new TableItem(getStatusName());
         } else {
             items[0] = new TableItem(getLastName());
             items[1] = new TableItem(getFirstName());
-            items[2] = new TableItem(getBirthday());
-            items[3] = new TableItem(getStatusName());
         }
-        setIconAndTooltipForEFBSyncAndGroups(items[0]);
+
+        String tooltip = createTooltipForGroups();
+        if (hasExtension) {
+			items[2] = new TableItem(getPersonExtension(false));
+			items[2].setToolTipText(tooltip);
+		} 
+
+        items[hasExtension ? 3 : 2] = new TableItem(getBirthday());
+        items[hasExtension ? 4 : 3] = new TableItem(getStatusName());
+
+        setIconAndTooltipForEFBSyncAndGroups(items[0], tooltip); // set icon and tooltip for the first column (name), so that it is visible even if the extension column is not shown
+        items[1].setToolTipText(tooltip); // set tooltip for the second column as well, so that it is visible even if the first column is not wide enough to show the full tooltip
         return items;
     }
+    
+    private String getPersonExtension(boolean withFieldNames) {
+    	StringBuilder result = new StringBuilder(200);
+    	String field1Name = Daten.efaConfig.getValueEfaDirektBoathouseExtPersonField1();
+    	String field2Name = Daten.efaConfig.getValueEfaDirektBoathouseExtPersonField2();
+    	String field1Value=null;
+    	String field2Value=null;
+    	String field1DisplayName="";
+    	String field2DisplayName="";
+    	
+    	if (field1Name.length() > 0) {
+			field1Value = getAsString(field1Name);
+			
+			if (withFieldNames && field1Value != null && !field1Value.isEmpty()) {
+				field1DisplayName = EfaConfig.personExtFields.get(field1Name);
+			}
+		}
+    	if (field2Name.length() > 0) {
+			field2Value = getAsString(field2Name);
+
+			if (withFieldNames && field2Value != null && !field2Value.isEmpty()) {
+				field2DisplayName = EfaConfig.personExtFields.get(field2Name);
+			}
+		}
+    	
+		if ((field1Value!=null && !field1Value.isEmpty()) || (field2Value!=null && !field2Value.isEmpty())) {
+			if (withFieldNames) {
+				result.append((field1Value!=null && !field1Value.isEmpty() ? "<tr><td align=left>"+field1DisplayName + "</td><td>" + field1Value +"</td></tr>" : ""));
+				result.append((field2Value!=null && !field2Value.isEmpty() ? "<tr><td align=left>"+field2DisplayName + "</td><td>" + field2Value +"</td></tr>" : ""));
+			} else {
+				result.append((field1Value!=null 
+					? field1Value.concat((field2Value!=null ? ", " + field2Value : "")) 
+					: (field2Value!=null ? field2Value : "")));
+			}
+		}
+		
+    	return result.toString();
+	}
     
     /**
      * Adds the EFBSync Icon for persons where the efbID is filled.
      * Adds a tooltip with the efbID to those persons.
      * @param theEntry TableItem for the person.
      */
-    private void setIconAndTooltipForEFBSyncAndGroups(TableItem theEntry) {
-    	String result = null;
+    private void setIconAndTooltipForEFBSyncAndGroups(TableItem theEntry, String tooltipForGroups) {
     	String efbID = getString(PersonRecord.EFBID);
     	if (efbID!=null) {
     		theEntry.addIcon(ImagesAndIcons.getIcon(ImagesAndIcons.IMAGE_MENU_EFBSYNC));
-    		result = "EFB Sync mit ID: "+efbID;
     	}
-
     	GroupRecord[] personGroups = getGroupList();
     	
     	if (personGroups != null && personGroups.length>0) {
     		theEntry.addIcon(createGroupPieIcon(personGroups, 16,16));
-			String addendum=International.getString("Gruppen")+":\n";
-			int count=0;
-    		for (int i=0; i<personGroups.length; i++) {
-    			addendum = addendum + (count++ == 0 ? "   " : "\n   ") + personGroups[i].getName();
-    		}
-    		if (result!=null) {
-    			result = result +"\n"+addendum;
-    		} else  {
-    			result = addendum;
-    		}
     	}
+		theEntry.setToolTipText(tooltipForGroups);
+    }
     
-		theEntry.setToolTipText(result);
-    
+    private String createTooltipForGroups() {
+    	String groupNames = this.getGroupsAsNameString();
+    	String efbID = getString(PersonRecord.EFBID);
+    	if ((groupNames!=null && !groupNames.isEmpty()) || efbID!=null ) {
+       		String toolTipBgColorText=(Daten.efaConfig.getToolTipSpecialColors() ? "bgcolor=\"#"+EfaUtil.getColor(Daten.efaConfig.getToolTipHeaderBackgroundColor())+"\"": "");
+       		String toolTipFontColorOpeningTag = (Daten.efaConfig.getToolTipSpecialColors() ? "<font color=\"#"+EfaUtil.getColor(Daten.efaConfig.getToolTipHeaderForegroundColor())+"\">": "");
+       		String toolTipFontColorClosingTag = (Daten.efaConfig.getToolTipSpecialColors() ? "</font>": "");
+    		
+    		StringBuilder sb = new StringBuilder(200);
+    		sb.append("<html><body><table border=0><tr ")
+    		.append(toolTipBgColorText)
+    		.append("><td align=left><b>")
+    		.append(toolTipFontColorOpeningTag).append(EfaUtil.escapeHtml(getQualifiedName())).append("</b></td></tr>"); // to ensure multi-line tooltip
+    		sb.append(toolTipFontColorClosingTag);
+    		sb.append(groupNames!=null && !groupNames.isEmpty() ? "<tr><td align=left>"+International.getString("Gruppen")+"</td><td>"+EfaUtil.escapeHtml(groupNames)+"</td></tr>" : "");
+    		sb.append(getPersonExtension(true)); // with field names
+    		sb.append(efbID!=null ? "<tr><td align=left>"+"Kanu-EFB ID"+"</td><td>"+EfaUtil.escapeHtml(efbID)+"</td></tr>" : ""); // add efbID to tooltip, if available
+    		return sb.toString();
+    		//return this.getQualifiedName()+ International.getString("Gruppen")+":\n   "+result;
+    	} else {
+    		return null;
+    	}
     }
 
    

--- a/de/nmichael/efa/data/storage/DataRecord.java
+++ b/de/nmichael/efa/data/storage/DataRecord.java
@@ -560,15 +560,33 @@ public abstract class DataRecord implements Cloneable, Comparable {
         
     }
 
+    /**
+	 * Returns a string with all field values separated by ";".
+	 * This is intended to used ONLY for filtering (checkbox filter set to "true") of records in the DataListDialog.
+	 * Do not use this for any other purpose, as the output format is not defined and may change without notice.
+	 * 
+	 * The field order is the same as defined in the respective DataRecord subclass.
+	 * Fields with empty or null values are not included in the output.
+	 * Also, some technical fields are not included in the output (LastModified, ChangeCount, ValidFrom, InvalidFrom, Invisible, Deleted).
+	 */
     public String getAllFieldsAsSeparatedText() {
         StringBuilder b = new StringBuilder();
         for (int i=0; i<getFieldCount(); i++) {
             if (b.length() > 1) {
                 b.append(";");
             }
-            String v = getAsText(getFieldName(i));
-            if (v != null && v.length() > 0) {
-                b.append(v);
+            String fieldName = getFieldName(i);
+            if (fieldName!= null && fieldName.length() > 0 
+            		&& !fieldName.equals(LASTMODIFIED)
+            		&& !fieldName.equals(CHANGECOUNT) 
+            		&& !fieldName.equals(VALIDFROM) 
+            		&& !fieldName.equals(INVALIDFROM) 
+            		&& !fieldName.equals(INVISIBLE) 
+            		&& !fieldName.equals(DELETED)) {
+	            String v = getAsText(fieldName);
+	            if (v != null && v.length() > 0) {
+	                b.append(v);
+	            }
             }
         }
         return b.toString();

--- a/de/nmichael/efa/gui/EfaGuiUtils.java
+++ b/de/nmichael/efa/gui/EfaGuiUtils.java
@@ -352,7 +352,7 @@ public class EfaGuiUtils {
 		}
 		
     	int maxDlgW=Daten.efaConfig.getValueMaxDialogWidth();
-    	int maxDlgH=Daten.efaConfig.getValueMaxDialogHeight()-20;
+    	int maxDlgH=Daten.efaConfig.getValueMaxDialogHeight()-60;
     	
     	//no max size for dialogs set? have a look at configured maximum screen width/height
     	if (maxDlgW<=0) {
@@ -379,12 +379,9 @@ public class EfaGuiUtils {
     	
     	// No size configured for dialogs or even efaBths window? 
     	// then use screen height/width as base
-    	if (maxDlgW<=0) {
-    		maxDlgW=Math.min(s.width-80,intendedMaxWidth);
-    	}
-    	if (maxDlgH<=0) {
-    		maxDlgH=Math.min(s.height-((1+1)*25), intendedMaxHeight);
-    	}
+    	maxDlgW=Math.min(s.width-80,intendedMaxWidth);
+
+    	maxDlgH=Math.min(s.height-((1+1)*25), intendedMaxHeight);
     	
 		return new Dimension(
 				(int) Math.round(maxDlgW), 

--- a/de/nmichael/efa/gui/dataedit/VersionizedDataEditDialog.java
+++ b/de/nmichael/efa/gui/dataedit/VersionizedDataEditDialog.java
@@ -231,7 +231,7 @@ public class VersionizedDataEditDialog extends UnversionizedDataEditDialog imple
 				//than the current screen size allows.
 				JScrollPane scrollPane = new JScrollPane(innerPanel);
 				scrollPane.setBorder(BorderFactory.createEmptyBorder(4,4,4,4));
-				scrollPane.setPreferredSize(EfaGuiUtils.getTabPanelPreferredSize(otherPanelHeight ,  this, 1100, 900));
+				scrollPane.setPreferredSize(EfaGuiUtils.getTabPanelPreferredSize(otherPanelHeight , this, 1000, 730));
 				scrollPane.getVerticalScrollBar().setUnitIncrement(12);
 				innerPanel.setLayout(new GridBagLayout());
 				panel.setLayout(new BorderLayout());

--- a/de/nmichael/efa/gui/util/Table.java
+++ b/de/nmichael/efa/gui/util/Table.java
@@ -293,7 +293,7 @@ public class Table extends JTable {
 					Rectangle l_cellRect=getCellRect(row, col, false);
 
 					//Obtain tooltip only in the first column.
-					String toolTip = (col==0) ? ((TableItem) getValueAt(row,col)).getToolTipText() : null;
+					String toolTip = (col<=2) ? ((TableItem) getValueAt(row,col)).getToolTipText() : null;
 					if (toolTip == null) {
 						if (l_cellRect.width >= l_component.getPreferredSize().width) {
 							// do not show any tooltip if the column has enough space for the value

--- a/de/nmichael/efa/gui/util/TableItem.java
+++ b/de/nmichael/efa/gui/util/TableItem.java
@@ -55,9 +55,6 @@ public class TableItem {
     
     public String getToolTipText() {
     	if (!this.invisible) {
-    		if (this.getIcons()!=null && this.getIcons().size()>0) {
-    			return this.txt +(this.toolTipText==null ? "" : "\n"+this.toolTipText);
-    		}
     		return this.toolTipText;
     	} else {
     		// Automatically add a prefix for the actual tooltip, if the record has invisible status.

--- a/efa_de.properties
+++ b/efa_de.properties
@@ -703,6 +703,7 @@ Erstelle_Statistik_f\u00fcr_den_Zeitraum_{from}_bis_{to}_...=Erstelle Statistik 
 Erste_HTML-Seite=Erste HTML-Seite
 Erster=Erster
 Erweiterte_Bearbeitungsfunktionen=Erweiterte Bearbeitungsfunktionen
+Erweiterung=Erweiterung
 Es_existieren_\u00dcbertr\u00e4ge_im_Ziel-Vereinsarbeitsbuch._Diese_l\u00f6schen?=Es existieren \u00dcbertr\u00e4ge im Ziel-Vereinsarbeitsbuch. Diese l\u00f6schen?
 Es_existiert_bereits_ein_gleichnamiger_Datensatz!=Es existiert bereits ein gleichnamiger Datensatz!
 Es_existiert_bereits_ein_\u00e4hnlicher_Datensatz!=Es existiert bereits ein \u00e4hnlicher Datensatz!

--- a/efa_en.properties
+++ b/efa_en.properties
@@ -710,6 +710,7 @@ Erster=First
 Erste_HTML-Seite=First HTML Page
 Erste_Ver\u00F6ffentlichung_am_15.07.2001=First release on July 15th, 2001
 Erweiterte_Bearbeitungsfunktionen=Extended editing functions
+Erweiterung=Extension
 Es_existieren_\u00DCbertr\u00E4ge_im_Ziel-Vereinsarbeitsbuch._Diese_l\u00F6schen?=There are carryovers in the target Club Workbook. Do you want to delete them?
 Es_existiert_bereits_ein_gleichnamiger_Datensatz\!=There is already a record of the same name\!
 Es_existiert_bereits_ein_\u00E4hnlicher_Datensatz\!=A similar record already exists\!

--- a/efa_fr.properties
+++ b/efa_fr.properties
@@ -822,6 +822,7 @@ Erstelle_Statistik_f\u00FCr_den_Zeitraum_{from}_bis_{to}_...=Cr\u00E9er la stati
 Erster=Premier
 Erste_HTML-Seite=Premi\u00e9re page HTML
 Erweiterte_Bearbeitungsfunktionen=Fonctions d'\u00E9dition avanc\u00E9es
+Erweiterung=Extension
 Es_existieren_\u00DCbertr\u00E4ge_im_Ziel-Vereinsarbeitsbuch._Diese_l\u00F6schen?=Il y a des reports dans le cahier de travail du club cible. Supprimer ceux-ci\u00A0?
 Es_existiert_bereits_ein_\u00E4hnlicher_Datensatz\!=Un jeu de donn\u00E9es similaire existe d\u00E9j\u00E0\u00A0\!
 Es_existiert_bereits_ein_gleichnamiger_Datensatz\!=Un ensemble de donn\u00E9es de m\u00EAme nom existe

--- a/eou/eou.xml
+++ b/eou/eou.xml
@@ -2,7 +2,7 @@
 <efaOnlineUpdate>
 <Version>
         <VersionID>2.5.3#2</VersionID>
-        <ReleaseDate>26.05.2026</ReleaseDate>
+        <ReleaseDate>27.05.2026</ReleaseDate>
         <DownloadUrl>TODO</DownloadUrl>
         <DownloadSize>TODO</DownloadSize>
      	<MinimumJavaVersion>1.8</MinimumJavaVersion>
@@ -11,15 +11,19 @@
         <ShowNotice lang="en">If you use efaCloud, make sure your server at least supports efaCloud Version 2.3.3. It is recommended to upgrade to EfaCloud 2.4.0_12 or above.</ShowNotice>
         <Changes lang="de">
         	<ChangeItem>Neu: EfaConfig: Bootshauslisten haben eine eigenständige Sektion in Bootshaus&gt;Bootslisten</ChangeItem>
+        	<ChangeItem>Neu: Admin-Bereich: Liste der Boote und Personen zeigen bei Bedarf eine Spalte mit den Zusatzfeldern an, und zeigen die Zusatzfelder im Tooltipp.</ChangeItem>
         	<ChangeItem>Bugfix: Besseres Layout für Bootshauslisten (mehr Abstände, Filter-Textfelder haben Standardhöhe von 21 pix)</ChangeItem>
-        	<ChangeItem>Bugfix: Größenbeschränkung der Größe von VersionizedDataEditDialog (Boote, Personen, Gruppen) auf max. 1100x900 und AdminEditDialog auf 700x700 Pixel</ChangeItem>
+        	<ChangeItem>Bugfix: Größenbeschränkung der Größe von VersionizedDataEditDialog (Boote, Personen, Gruppen) auf max. 1000x700 und AdminEditDialog auf 700x700 Pixel</ChangeItem>
 			<ChangeItem>Bugfix: Einige Dialoge schlossen sich nicht beim Betätigen von ESC</ChangeItem>
+			<ChangeItem>Bugfix: Admin-Bereich: Suche in den Dataedit-Dialogen sucht nicht mehr in technischen Feldern</ChangeItem>
         </Changes>
         <Changes lang="en">
         	<ChangeItem>New: EfaConfig: Boathouse lists have their own section in Boathouse&gt;Boat lists</ChangeItem>
+        	<ChangeItem>New: Admin area: Boat and person lists optionally show a column with the additional fields, and show the additional fields in the tooltip.</ChangeItem>
         	<ChangeItem>Bugfix: Improved layout for boathouse lists (more spacing, filter text fields have a default height of 21 pixels)</ChangeItem>
-        	<ChangeItem>Bugfix: Size restriction of versionized data edit dialogs (boats, persons, groups) to max. 1100x900 and admin edit dialog to 700x700 pixels</ChangeItem>
+        	<ChangeItem>Bugfix: Size restriction of versionized data edit dialogs (boats, persons, groups) to max. 1000x700 and admin edit dialog to 700x700 pixels</ChangeItem>
         	<ChangeItem>Bugfix: Some dialogs did not close when pressing ESC</ChangeItem>
+        	<ChangeItem>Bugfix: Admin area: Search in the data edit dialogs no longer searches in technical fields</ChangeItem>
         </Changes>
 	</Version>
 	<Version>


### PR DESCRIPTION
- New: EfaConfig: Boathouse lists have their own section in Boathouse&gt;Boat lists
- New: Admin area: Boat and person lists optionally show a column with the additional fields, and show the additional fields in the tooltip.
- Bugfix: Improved layout for boathouse lists (more spacing, filter text fields have a default height of 21 pixels)
- Bugfix: Size restriction of versionized data edit dialogs (boats, persons, groups) to max. 1000x700 and admin edit dialog to 700x700 pixels
- Bugfix: Some dialogs did not close when pressing ESC
- Bugfix: Admin area: Search in the data edit dialogs no longer searches in technical fields