### PR TITLE
Bugfix efaBase not exiting correctly

### DIFF
--- a/de/nmichael/efa/Daten.java
+++ b/de/nmichael/efa/Daten.java
@@ -78,9 +78,9 @@ public class Daten {
 	public final static String VERSION = "2.5.3"; // Version für die Ausgabe (z.B. 2.1.0, kann aber
 																	// auch Zusätze wie "alpha" o.ä. enthalten)
 
-	public final static String VERSIONID = "2.5.3_#9"; // VersionsID: Format: "X.Y.Z_MM"; final-Version z.B. 1.4.0_00;
+	public final static String VERSIONID = "2.5.3_#10"; // VersionsID: Format: "X.Y.Z_MM"; final-Version z.B. 1.4.0_00;
 														// beta-Version z.B. 1.4.0_#1  //# is not good, is used in efa.data.Waters 
-	public final static String VERSIONRELEASEDATE = "19.07.2026"; // Release Date: TT.MM.JJJJ
+	public final static String VERSIONRELEASEDATE = "01.08.2026"; // Release Date: TT.MM.JJJJ
 	public final static String MAJORVERSION = "2";
 	public final static String PROGRAMMID = "EFA.253"; // Versions-ID für Wettbewerbsmeldungen
 	public final static String PROGRAMMID_DRV = "EFADRV.253"; // Versions-ID für Wettbewerbsmeldungen

--- a/de/nmichael/efa/gui/EfaBaseFrame.java
+++ b/de/nmichael/efa/gui/EfaBaseFrame.java
@@ -3259,7 +3259,7 @@ public class EfaBaseFrame extends BaseDialog implements IItemListener {
             long tstmp = getValidAtTimestamp(myRecord);
 
             DataTypeList<UUID> groupIdList = currentBoat.getAllowedGroupIdList();
-            Boolean currentBoatHasGroups = (groupIdList != null && groupIdList.length() > 0);
+            boolean currentBoatHasGroups = (groupIdList != null && groupIdList.length() > 0);
             
                 String nichtErlaubt = null;
                 int nichtErlaubtAnz = 0;
@@ -4468,7 +4468,8 @@ public class EfaBaseFrame extends BaseDialog implements IItemListener {
     	return cancel(false);
     }
 
-    public boolean cancel(Boolean keyESCAction) {
+    @Override
+    public boolean cancel(boolean keyESCAction) {
     	
         if (isModeBoathouse()) {
             efaBoathouseHideEfaFrame();

--- a/de/nmichael/efa/gui/EfaBaseFrameMultisession.java
+++ b/de/nmichael/efa/gui/EfaBaseFrameMultisession.java
@@ -1380,7 +1380,7 @@ public class EfaBaseFrameMultisession extends EfaBaseFrame implements IItemListe
 
 
         DataTypeList<UUID> groupIdList = curBoat.getAllowedGroupIdList();
-        Boolean currentBoatHasGroups = (groupIdList != null && groupIdList.length() > 0);
+        boolean currentBoatHasGroups = (groupIdList != null && groupIdList.length() > 0);
 
         
             String nichtErlaubt = null;

--- a/de/nmichael/efa/gui/EfaBoathouseFrame.java
+++ b/de/nmichael/efa/gui/EfaBoathouseFrame.java
@@ -2844,7 +2844,7 @@ public class EfaBoathouseFrame extends BaseFrame implements IItemListener {
      * Checks if a boat item in the available Boat list is selected,
      * and shows the efaBaseFrameMultipleSession dialog if so.
      *  
-     * @param lateEntry Boolean: Late Entry mode true or false?
+     * @param lateEntry boolean: Late Entry mode true or false?
      */
     private void actionForMultiple(boolean lateEntry) {
     	alive();

--- a/eou/eou.xml
+++ b/eou/eou.xml
@@ -1,6 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <efaOnlineUpdate>
 	<Version>
+        <VersionID>2.5.3#10</VersionID>
+        <ReleaseDate>01.08.2026</ReleaseDate>
+        <DownloadUrl>TODO</DownloadUrl>
+        <DownloadSize>TODO</DownloadSize>
+     	<MinimumJavaVersion>1.8</MinimumJavaVersion>
+		<MinimumEfaCloudVersion>2.3.3</MinimumEfaCloudVersion>
+        <ShowNotice lang="de">Wenn efaCloud eingesetzt wird, muss der Server mindestens Version 2.3.3 unterstützen. EfaCloud 2.4.0_12 und höher werden empfohlen.</ShowNotice>
+        <ShowNotice lang="en">If you use efaCloud, make sure your server at least supports efaCloud Version 2.3.3. It is recommended to upgrade to EfaCloud 2.4.0_12 or above.</ShowNotice>
+        <Changes lang="de">
+        	<ChangeItem>Bugfix: efaBase blieb seit efa 2.5.3#3 beim Beenden im Hintergrund hängen. efaBase lässt sich nun wieder korrekt beenden.</ChangeItem>
+        	<ChangeItem>Bugfix: Kleinere Darstellungsfehler bei GUI-Elementen mit abgerundeten Ecken wurden behoben.</ChangeItem>
+        </Changes>
+        <Changes lang="en">
+        	<ChangeItem>Bugfix: efaBase has been hanging in the background since efa 2.5.3#3 when exiting. efaBase can now be exited correctly again.</ChangeItem>
+			<ChangeItem>Bugfix: Minor display errors concerning GUI elements with rounded corners have been fixed.</ChangeItem>
+        </Changes>
+	</Version>
+	<Version>
         <VersionID>2.5.3#9</VersionID>
         <ReleaseDate>19.07.2026</ReleaseDate>
         <DownloadUrl>TODO</DownloadUrl>


### PR DESCRIPTION
Bugfix: efaBase has been hanging in the background since efa 2.5.3#3 when exiting. efaBase can now be exited correctly again.